### PR TITLE
Fix type specialization and inference for empty lists.

### DIFF
--- a/labrad/types.py
+++ b/labrad/types.py
@@ -992,7 +992,7 @@ class LRList(LRType):
         return (type(other) == LRAny or
                 (type(self) == type(other) and
                  self.depth == other.depth and
-                 (other.elem is None or self.elem <= other.elem)))
+                 (other.elem is None or type(other.elem) == LRNone or self.elem <= other.elem)))
 
     def __eq__(self, other):
         """Test whether this type is equal to another.
@@ -1004,7 +1004,7 @@ class LRList(LRType):
                 self.elem == other.elem)
 
     def isFullySpecified(self):
-        return self.elem.isFullySpecified()
+        return type(self.elem) != LRNone and self.elem.isFullySpecified()
 
     def __unflatten__(self, s, endianness):
         data = s.get(self.__width__(Buffer(s), endianness))


### PR DESCRIPTION
This fixes the typeSpecialization test in test_types.py. The type of an empty list is written as *_ to indicate that the element type is undefined. In pylabrad, this is represented by LRList(LRNone()), since LRNone renders as '_'. However, we need to consider such an empty list as being a subtype of any other list type so that specialization will work properly.
