### PR TITLE
Add support for flattening unicode, bytes, bytearray, and memoryview

### DIFF
--- a/labrad/types.py
+++ b/labrad/types.py
@@ -287,7 +287,7 @@ def unflatten(s, t, endianness='>'):
     """
     if isinstance(t, str):
         t = parseTypeTag(t)
-    if isinstance(s, str):
+    if not isinstance(s, Buffer):
         s = Buffer(s)
     return t.__unflatten__(s, endianness)
 
@@ -607,14 +607,22 @@ class LRStr(LRType, Singleton):
 
     def __unflatten__(self, s, endianness):
         n = unpack(endianness + 'i', s.get(4))[0]
-        return s.get(n)
+        return bytes(s.get(n))
 
     def __flatten__(self, s, endianness):
-        if not isinstance(s, str):
+        if not isinstance(s, (str, bytes, bytearray, memoryview, unicode)):
             raise FlatteningError(s, self)
-        return pack(endianness + 'I', len(s)) + s, self
+        if isinstance(s, memoryview):
+            s = s.tobytes()
+        elif isinstance(s, unicode):
+            s = s.encode('utf-8')
+        return pack(endianness + 'I', len(s)) + bytes(s), self
 
 registerType(str, LRStr())
+registerType(bytes, LRStr())
+registerType(bytearray, LRStr())
+registerType(memoryview, LRStr())
+registerType(unicode, LRStr())
 
 
 def timeOffset():


### PR DESCRIPTION
Fixes #42; contains the answer to life, the universe, and everything.

This allows unicode strings to be flattened (encoded as UTF-8). Unflattening is a little trickier. Right now, pylabrad always unflattens into a canonical type for a given labrad data type (the LazyList was an attempt to defer the choice of how to unflatten until later, and we all know how well that worked out...). I think we'll need a different mechanism to allow programs to specify what python type to unflatten a given piece of labrad data to (e.g. in server settings, do I want some data as a byte string or unicode text?). Eventually we may want a completely separate labrad type for bytes versus unicode text, but for now that's out of scope.