### PR TITLE
Modify inUnitsOf to return self if converting to the same unit.

### DIFF
--- a/labrad/units.py
+++ b/labrad/units.py
@@ -399,6 +399,8 @@ class WithUnit(object):
         @raises TypeError: if any of the specified units are not compatible
         with the original unit
         """
+        if unit == self.unit:
+            return self
         u = Unit(unit)
         return self[u] * u
 


### PR DESCRIPTION
Small optimization, but we saw a non-negligible performance improvement in code that does a lot of unit computations, because the values are typically expressed in the units we want to convert to and this method was doing unneccessary work.