### PR TITLE
Update travis config to run tests on new infrastructure with latest manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
 language: python
+sudo: false
 python:
   - "2.7"
 install:
   - pip install .
-  - pip install coveralls
-  - pip install numpy
-  - pip install pytest
-  - pip install twisted
+  - pip install numpy twisted
+  - pip install pytest coveralls
+env:
+  - SCALABRAD_VERSION=0.3.3
+cache:
+  directories:
+    - $HOME/scalabrad-$SCALABRAD_VERSION
 before_script:
-  - wget https://bintray.com/artifact/download/maffoo/generic/scalabrad-0.2-SNAPSHOT.tar.gz -O /tmp/scalabrad-0.2-SNAPSHOT.tar.gz
-  - tar -xvf /tmp/scalabrad-0.2-SNAPSHOT.tar.gz
-  - export PATH=$PATH:$PWD/scalabrad-0.2-SNAPSHOT/bin/
+  - bash scripts/test/install-scalabrad.sh
+  - export PATH=$PATH:$HOME/scalabrad-$SCALABRAD_VERSION/bin/
 script: scripts/test/test.sh
 after_success:
   - coveralls

--- a/labrad/test/test_refresh.py
+++ b/labrad/test/test_refresh.py
@@ -1,7 +1,9 @@
+import time
+
 import pytest
 
 import labrad
-from labrad import util
+from labrad import types as T, util
 from labrad.server import LabradServer, setting
 
 class RefreshServer1(LabradServer):
@@ -39,15 +41,24 @@ def test_refresh():
             assert hasattr(cxn, 'refresh_test_server')
             rts = cxn.refresh_test_server
 
+            def type_list(strs):
+                return [T.parseTypeTag(s) for s in strs]
+
+            def same_types(a, b):
+                return type_list(a) == type_list(b)
+
             assert hasattr(rts, 'greet')
-            assert rts.greet.accepts == ['_']
-            assert rts.greet.returns == ['s']
+            assert same_types(rts.greet.accepts, ['_'])
+            assert same_types(rts.greet.returns, ['s'])
 
             assert hasattr(rts, 'go_away')
-            assert rts.go_away.accepts == ['_']
-            assert rts.go_away.returns == ['_']
+            assert same_types(rts.go_away.accepts, ['_'])
+            assert same_types(rts.go_away.returns, ['_'])
 
             assert rts.greet() == 'hello!'
+
+        # pause before refreshing after server disconnect
+        time.sleep(1)
 
         cxn.refresh()
         assert not hasattr(cxn, 'refresh_test_server')
@@ -59,12 +70,12 @@ def test_refresh():
             # check the old rts we got earlier, as well as the cxn attribute
             for srv in [rts, cxn.refresh_test_server]:
                 assert hasattr(srv, 'greet')
-                assert srv.greet.accepts == ['s']
-                assert srv.greet.returns == ['s']
+                assert same_types(srv.greet.accepts, ['s'])
+                assert same_types(srv.greet.returns, ['s'])
 
                 assert hasattr(srv, 'add')
-                assert srv.add.accepts == ['(ii)']
-                assert srv.add.returns == ['i']
+                assert same_types(srv.add.accepts, ['(ii)'])
+                assert same_types(srv.add.returns, ['i'])
 
                 assert not hasattr(srv, 'go_away')
 

--- a/scripts/test/install-scalabrad.sh
+++ b/scripts/test/install-scalabrad.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# exit on any error
+set -e
+
+ARCHIVE=scalabrad-${SCALABRAD_VERSION}.tar.gz
+
+# check to see if scalabrad folder is empty
+if [ ! -d "$HOME/scalabrad-${SCALABRAD_VERSION}/bin" ]; then
+  wget https://bintray.com/artifact/download/labrad/generic/$ARCHIVE -O $HOME/$ARCHIVE;
+  cd $HOME && tar -xvf $ARCHIVE;
+else
+  echo "Using cached scalabrad-${VERSION}.";
+fi

--- a/scripts/test/test.py
+++ b/scripts/test/test.py
@@ -1,4 +1,6 @@
+import sys
+
 import pytest
 
 if __name__ == '__main__':
-    pytest.main()
+    sys.exit(pytest.main())

--- a/scripts/test/test.sh
+++ b/scripts/test/test.sh
@@ -5,7 +5,7 @@ export LABRADPASSWORD=testpass
 export LABRADPORT=7777
 
 # start labrad manager
-labrad --password ${LABRADPASSWORD} --port ${LABRADPORT} 1>.labrad.log 2>.labrad.err.log &
+labrad 1>.labrad.log 2>.labrad.err.log &
 sleep 20
 
 # start python test server
@@ -14,3 +14,9 @@ sleep 20
 
 # run the tests
 python $(dirname $0)/test.py -v . && coverage run --source=labrad $(dirname $0)/test.py -v .
+STATUS=$?
+
+echo "=== .labrad.log ===" && cat .labrad.log && echo
+echo "=== .test_server.log ===" && cat .test_server.log && echo
+
+exit $STATUS


### PR DESCRIPTION
Travis has introduced a new "containerized" infrastructure that lets tests startup and run faster and also allows us to take advantage of caching of downloaded dependencies such as the scalabrad manager (details here: http://docs.travis-ci.com/user/migrating-from-legacy/). This change updates the travis config to take advantage of the new infrastructure. While working on the build, we made improvements to test_refresh.py (it was brittle due to comparing type tag strings instead of type objects, and was sensitive to timing) and to the test runner script (it was swallowing the return code of the test script).