### PR TITLE
Actually parse command line options when running node directly.

### DIFF
--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -846,7 +846,7 @@ def makeService(options):
 
 if __name__ == '__main__':
     config = NodeOptions()
-    config.parseOptions
+    config.parseOptions()
     service = makeService(config)
     service.startService()
     reactor.run()


### PR DESCRIPTION
The node server picks up the supplied name when run as a `twistd` plugin, but when running the file directly it was not actually doing the parsing.