### PR TITLE
Refresh server settings by name instead of ID

### DIFF
--- a/labrad/backend.py
+++ b/labrad/backend.py
@@ -451,6 +451,15 @@ class ManagerService:
         description, accepts, returns, notes = resp[0][1]
         return (description, accepts, returns, notes)
 
+    def getSettingInfoByName(self, serverID, settingName):
+        """Get information about a setting using its name."""
+        packet = [(C.HELP, (long(serverID), settingName)),
+                  (C.LOOKUP, (long(serverID), settingName))]
+        resp = self._send(packet)
+        description, accepts, returns, notes = resp[0][1]
+        ID = resp[1][1][1]
+        return (description, accepts, returns, notes, ID)
+
     def _send(self, packet, *args, **kw):
         """Send a request to the manager and wait for the result."""
         return self.cxn.sendRequest(C.MANAGER_ID, packet, *args, **kw).wait()

--- a/labrad/client.py
+++ b/labrad/client.py
@@ -87,8 +87,8 @@ class SettingWrapper(object):
 
     def _refresh(self):
         if not self._refreshed:
-            info = self._mgr.getSettingInfo(self._server.ID, self.ID)
-            self.__doc__, self._accepts, self._returns, self._notes = info
+            info = self._mgr.getSettingInfoByName(self._server.ID, self.name)
+            self.__doc__, self._accepts, self._returns, self._notes, self.ID = info
             self._refreshed = True
 
     def refresh(self):

--- a/labrad/manager.py
+++ b/labrad/manager.py
@@ -82,6 +82,16 @@ class AsyncManager:
         returnValue((description, accepts, returns, notes))
 
     @inlineCallbacks
+    def getSettingInfoByName(self, serverID, settingName):
+        """Get information about a setting using its name."""
+        packet = [(C.HELP, (long(serverID), settingName)),
+                  (C.LOOKUP, (long(serverID), settingName))]
+        resp = yield self._send(packet)
+        description, accepts, returns, notes = resp[0][1]
+        ID = resp[1][1][1]
+        returnValue((description, accepts, returns, notes, ID))
+
+    @inlineCallbacks
     def subscribeToNamedMessage(self, name, ID, enable=True):
         """Subscribe to or stop a named message."""
         packet = [(C.MESSAGE_SUBSCRIBE, (name, long(ID), enable))]

--- a/labrad/test/test_refresh.py
+++ b/labrad/test/test_refresh.py
@@ -23,13 +23,25 @@ class RefreshServer2(LabradServer):
     """Second version of the refresh server, with different settings."""
     name = 'Refresh Test Server'
 
-    @setting(10, name='s', returns='s')
+    @setting(1, name='s', returns='s')
     def greet(self, c, name):
         return 'hello, {}!'.format(name)
 
-    @setting(12, a='i', b='i', returns='i')
+    @setting(2, a='i', b='i', returns='i')
     def add(self, c, a, b):
         return a + b
+
+class RefreshServer3(LabradServer):
+    """Third version of the refresh server, with original settings but differing IDs."""
+    name = 'Refresh Test Server'
+
+    @setting(10, returns='s')
+    def greet(self, c):
+        return 'hello!'
+
+    @setting(20, returns='_')
+    def go_away(self, c):
+        pass
 
 def test_refresh():
     with labrad.connect() as cxn:
@@ -81,6 +93,28 @@ def test_refresh():
 
                 assert srv.greet('tester') == 'hello, tester!'
                 assert srv.add(100, 101) == 201
+
+        # pause before refreshing after server disconnect
+        time.sleep(1)
+
+        cxn.refresh()
+        assert not hasattr(cxn, 'refresh_test_server')
+
+        with util.syncRunServer(RefreshServer3()):
+            cxn.refresh()
+            assert hasattr(cxn, 'refresh_test_server')
+
+            # check the old rts we got earlier, as well as the cxn attribute
+            for srv in [rts, cxn.refresh_test_server]:
+                assert hasattr(rts, 'greet')
+                assert same_types(rts.greet.accepts, ['_'])
+                assert same_types(rts.greet.returns, ['s'])
+
+                assert hasattr(rts, 'go_away')
+                assert same_types(rts.go_away.accepts, ['_'])
+                assert same_types(rts.go_away.returns, ['_'])
+
+                assert rts.greet() == 'hello!'
 
 if __name__ == '__main__':
     pytest.main(['-v', __file__])

--- a/labrad/test/test_refresh.py
+++ b/labrad/test/test_refresh.py
@@ -23,11 +23,11 @@ class RefreshServer2(LabradServer):
     """Second version of the refresh server, with different settings."""
     name = 'Refresh Test Server'
 
-    @setting(1, name='s', returns='s')
+    @setting(10, name='s', returns='s')
     def greet(self, c, name):
         return 'hello, {}!'.format(name)
 
-    @setting(2, a='i', b='i', returns='i')
+    @setting(12, a='i', b='i', returns='i')
     def add(self, c, a, b):
         return a + b
 


### PR DESCRIPTION
Setting names are what code is written in terms of, and in that sense are more stable than IDs.  This branch changes setting wrappers to refresh using their name instead of their ID.  Now any combination of changes in setting name and ID are refreshed correctly.  Modified existing unit test to include this bug, and passes in this branch.  Addresses the bug identified in #145.