### PR TITLE
ClientTests launch python_test_server using context manager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ Tests
 -----
 
 New code should have tests, and changes to existing code should not break existing tests.
-To run the test suite, you'll need to have `pytest` installed.
-In addition, the tests assume that the python test server is running, so you'll need to spin up a labrad manager and run the test server located in `labrad/servers/test_server.py`.
-Then run `py.test` from the command line when in the pylabrad directory.
+To run the test suite, you'll need to have `pytest` installed, then run `py.test` from the command line when in the pylabrad directory.
 
 Migration note
 --------------

--- a/labrad/test/test_client.py
+++ b/labrad/test/test_client.py
@@ -2,10 +2,22 @@ import unittest
 
 import labrad
 from labrad import types as T
+from labrad.servers.test_server import TestServer
+from labrad.util import syncRunServer
 
 TEST_STR = 'this is a test, this is only a test'
 
 class ClientTests(unittest.TestCase):
+    def run(self, result=None):
+        """Override the TestCase run method to launch the test server.
+
+        This seems to be the cleanest solution for effectively using a
+        context manager as part of a test fixture.  This method then calls
+        the usual test fixture setUp and tearDown within this context.
+        """
+        with syncRunServer(TestServer()):
+            super(ClientTests, self).run(result)
+
     def setUp(self):
         self.cxn = labrad.connect()
 


### PR DESCRIPTION
Utilizes the syncRunServer context manager as a test fixture by overriding the unittest.TestCase run method.  Also updated front-page docs to un-do yesterday's change :)  Closes #148 