### PR TITLE
Fix labrad.util.syncRunServer to run server shutdown hooks.

### DIFF
--- a/labrad/util/__init__.py
+++ b/labrad/util/__init__.py
@@ -403,21 +403,20 @@ def syncRunServer(srv, host=C.MANAGER_HOST, port=C.MANAGER_PORT, password=None):
 
     @inlineCallbacks
     def start_server():
-        connector = reactor.connectTCP(host, port, srv)
+        reactor.connectTCP(host, port, srv)
         yield srv.onStartup()
-        returnValue(connector)
 
     @inlineCallbacks
     def stop_server():
+        srv.disconnect()
         yield srv.onShutdown()
 
     thread.startReactor()
-    connector = blockingCallFromThread(reactor, start_server)
+    blockingCallFromThread(reactor, start_server)
     try:
         yield
     finally:
         try:
-            connector.disconnect()
             blockingCallFromThread(reactor, stop_server)
         except Exception:
             pass # don't care about exceptions here

--- a/labrad/util/test/test_sync_run_server.py
+++ b/labrad/util/test/test_sync_run_server.py
@@ -1,0 +1,25 @@
+import threading
+
+import pytest
+
+from labrad.server import LabradServer
+from labrad import util
+
+def test_sync_run_server():
+    """Ensure that syncRunServer runs the stopServer method on shutdown."""
+    event = threading.Event()
+
+    class TestServer(LabradServer):
+        name = "TestServer"
+
+        def stopServer(self):
+            event.set()
+
+    server = TestServer()
+    with util.syncRunServer(server):
+        pass
+    if not event.wait(0.5):
+        raise Exception('event not set in stopServer method')
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])


### PR DESCRIPTION
Fixes #153