### PR TITLE
Fix evalLRData to allow None for Value and Complex units.

### DIFF
--- a/labrad/test/test_eval_lr_data.py
+++ b/labrad/test/test_eval_lr_data.py
@@ -1,0 +1,57 @@
+import math
+
+import pytest
+
+import labrad.types as T
+from labrad.units import Complex, Value
+
+
+def test_eval_value_with_none_for_units():
+    assert T.evalLRData("""Value(1.0, None)""") == Value(1.0, '')
+
+
+def test_eval_complex_with_none_for_units():
+    assert T.evalLRData("""Complex(1.1, None)""") == Complex(1.1, '')
+
+
+def test_eval_cluster_with_value_and_complex():
+    assert (T.evalLRData("""(Value(1.0, None), Complex(2.0, None))""") ==
+            (Value(1.0, ''), Complex(2.0, '')))
+
+
+def test_eval_nan():
+    s = T.reprLRData(float('nan'))
+    n = T.evalLRData(s)
+    assert math.isnan(n)
+
+    s2 = T.reprLRData((float('nan'), 'this is a test'))
+    n2, _ = T.evalLRData(s2)
+    assert math.isnan(n2)
+
+
+def test_eval_positive_infinity():
+    s = T.reprLRData(float('inf'))
+    n = T.evalLRData(s)
+    assert math.isinf(n)
+    assert n > 0
+
+    s2 = T.reprLRData((float('inf'), 'this is a test'))
+    n2, _ = T.evalLRData(s2)
+    assert math.isinf(n2)
+    assert n2 > 0
+
+
+def test_eval_negative_infinity():
+    s = T.reprLRData(float('-inf'))
+    n = T.evalLRData(s)
+    assert math.isinf(n)
+    assert n < 0
+
+    s2 = T.reprLRData((float('-inf'), 'this is a test'))
+    n2, _ = T.evalLRData(s2)
+    assert math.isinf(n2)
+    assert n2 < 0
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -400,18 +400,45 @@ def _flatten_to(obj, types, endianness):
 # Evaluation functions
 
 def evalLRData(s):
-    """
-    Evaluate LR data in a namespace with all LRTypes.
+    """Evaluate labrad data from string form produced by reprLRData.
 
-    What is this for? -DTS
+    DEPRECATED
+
+    The format produced by reprLRData has been deprecated, and this function
+    is kept solely for backwards compatibility to load data stored with the
+    old format.
     """
-    return eval(s)
+
+    # Value and Complex constructors previously allowed the unit parameter
+    # to be None, and old data may have been saved that way. These shims
+    # convert the unit to '' instead and then call the real constructors.
+    def _Value(x, unit=''):
+        if unit is None:
+            unit = ''
+        return U.Value(x, unit)
+
+    def _Complex(x, unit=''):
+        if unit is None:
+            unit = ''
+        return U.Complex(x, unit)
+
+    globs = globals()
+    globs['Value'] = _Value
+    globs['Complex'] = _Complex
+    globs['nan'] = float('nan')
+    globs['inf'] = float('inf')
+    return eval(s, globs)
 
 def reprLRData(s):
-    """
-    Make a repr of LR data in a namespace with all LRTypes.
+    """Make a string repr of labrad data that can be parsed with evalLRData.
 
-    What is this for? -DTS
+    DEPRECATED
+
+    This was an attempt to create a human-readable string representation of
+    labrad data suitable for storing small amounts of data and reading it
+    in later. It was used in early versions of the data vault, and is kept
+    here for backwards-compatibility only. This should not be used for new
+    applications; instead, just use the standard wire-format for serialization.
     """
     return repr(s)
 


### PR DESCRIPTION
This is needed for backwards compatibility with data stored in the old format, since Value and Complex previously allowed None as a unit.

I've added a couple of unit tests for the known cases where backwards compatibility is a problem. Before we merge this, I'm going to run over all the data we have saved in the data vault currently to see if any other problems crop up and will add more test cases as needed.

Fixes #159