### PR TITLE
Add 'y' type tag for 'bytes'.  Right now, it unflattens as string

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -37,6 +37,7 @@ class LabradTypesTests(unittest.TestCase):
             'w': T.LRWord(),
             's': T.LRStr(),
             't': T.LRTime(),
+            'y': T.LRBytes(),
 
             # clusters
             'ii': T.LRCluster(T.LRInt(), T.LRInt()),
@@ -342,6 +343,13 @@ class LabradTypesTests(unittest.TestCase):
         data = datetime.now()
         data2 = T.evalLRData(repr(data))
         self.assertEquals(data, data2)
+
+    def testUnicodeBytes(self):
+        foo = T.flatten('foo bar')
+        self.assertEquals(foo, T.flatten(u'foo bar'))
+        self.assertEquals(str(foo.tag), 's')
+        self.assertEquals(T.unflatten(foo.bytes, 'y'), 'foo bar')
+        self.assertEquals(T.unflatten(*T.flatten('foo bar', ['y'])), 'foo bar')
 
 if __name__ == "__main__":
     unittest.main()

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -651,12 +651,37 @@ class LRStr(LRType, Singleton):
         return s.get(n)
 
     def __flatten__(self, s, endianness):
+        if isinstance(s, unicode):
+            s = s.encode('UTF-8')
         if not isinstance(s, str):
             raise FlatteningError(s, self)
         return pack(endianness + 'I', len(s)) + s, self
 
 registerType(str, LRStr())
+registerType(unicode, LRStr())
 
+class LRBytes(LRType, Singleton):
+    """A raw 8-bit byte string."""
+    tag = 'y'
+    isFixedWidth = False
+
+    def __width__(self, s, endianness):
+        width = unpack(endianness + 'i', s.get(4))[0]
+        s.skip(width)
+        return 4 + width
+
+    def __unflatten__(self, s, endianness):
+        n = unpack(endianness + 'i', s.get(4))[0]
+        return s.get(n)
+
+    def __flatten__(self, s, endianness):
+        if not isinstance(s, str):
+            raise FlatteningError(s, self)
+        return pack(endianness + 'I', len(s)) + s, self
+
+# Since bytes is an alias for str in python 2.7, don't enable this
+# until we are ready to cut over.
+# registerType(bytes, LRBytes)
 
 def timeOffset():
     now = time.time()

--- a/labrad/util/hydrant.py
+++ b/labrad/util/hydrant.py
@@ -31,6 +31,7 @@ def randType(noneOkay=True, listOkay=True, nStructs=0):
         T.LRInt,
         T.LRWord,
         T.LRStr,
+        T.LRBytes,
         T.LRTime,
         lambda: T.LRValue(randUnits()),
         lambda: T.LRComplex(randUnits()),
@@ -57,6 +58,7 @@ def randValue(t):
     if isinstance(t, T.LRInt): return genInt()
     if isinstance(t, T.LRWord): return genWord()
     if isinstance(t, T.LRStr): return genStr()
+    if isinstance(t, T.LRBytes): return genStr()
     if isinstance(t, T.LRTime): return genTime()
     if isinstance(t, T.LRComplex): return genComplex(t.unit) # check complex before value
     if isinstance(t, T.LRValue): return genValue(t.unit)


### PR DESCRIPTION
but is never generated unless requested explicitly.  This is the first step in supporting unicode.