### PR TITLE
Change error message when a server exists

### DIFF
--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -316,7 +316,7 @@ class LabradProtocol(protocol.Protocol):
         try:
             resp = yield self.sendRequest(C.MANAGER_ID, [(0L, (1L,) + ident)])
         except Exception:
-            raise errors.LoginFailedError('Bad identification.')
+            raise errors.LoginFailedError('Bad identification (Server of same name already running?)')
         self.ID = resp[0][1] # get assigned ID
 
 


### PR DESCRIPTION
This clarifies the error message when you fail to identify to the manager.  99% of the time this is because you are starting a server that is already running.