### PR TITLE
Fix tab completion for ipython 4.

### DIFF
--- a/labrad/client.py
+++ b/labrad/client.py
@@ -219,11 +219,12 @@ class HasDynamicAttrs(object):
         if now:
             self._refresh()
 
-    def _getAttributeNames(self):
-        """Return a list of dynamic attributes, for tab-completion"""
+    def __dir__(self):
+        """Return a list of attributes for tab-completion.
+        """
         self.refresh() # force refresh so the list is current
-        return sorted(self._attrs.keys())
-
+        return sorted(set(self._attrs.keys() + self.__dict__.keys() + dir(type(self))))
+    
     def __getattr__(self, key):
         return self._attrs[key]
 


### PR DESCRIPTION
The old method was from a shell called pycrust, and was supported by
old version of ipython.  Ipython 4.0 uses `__dir__`.

fixes #167.  I have tested this in ipython 1.2.1 and ipython 4.0, so I don't think we need the backwards compatible function for anything.