### PR TITLE
U/ejeffrey/requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ sudo: false
 python:
   - "2.7"
 install:
+  - cat requirements.txt | perl -p -i -e 's/>=/==/g' > exact_requirements.txt
+  - pip install -r exact_requirements.txt
   - pip install .
-  - pip install numpy twisted pyOpenSSL
   - pip install pytest coveralls
 env:
-  - SCALABRAD_VERSION=0.5.0
+  - SCALABRAD_VERSION=0.5.1
 cache:
   directories:
     - $HOME/scalabrad-$SCALABRAD_VERSION

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy >= 1.9.1
+twisted >= 14.0.0
+pyOpenSSL >= 0.13


### PR DESCRIPTION
I have determined that TLS support requires twisted 14.0.0 or later and updated the requirements to reflect this.  The travis build will use version 14 exactly.  We either need to bump our numpy requirement to 1.9.1 or fix travis to cache that version so we don't have to rebuild numpy every time.