### PR TITLE
Check for twisted version with SSL support

### DIFF
--- a/labrad/constants.py
+++ b/labrad/constants.py
@@ -20,6 +20,9 @@ Important constants that show up throughout the code.
 """
 
 import os
+import labrad.crypto
+
+DEFAULT_TLS = 'starttls' if labrad.crypto.TLS else 'off'
 
 def check_tls_mode(tls):
     """Check that provided tls mode is valid and convert to canonical form.
@@ -49,7 +52,7 @@ def check_tls_mode(tls):
 # defaults for the labrad manager
 MANAGER_ID = 1
 MANAGER_PORT = int(os.environ.get('LABRADPORT', 7682))
-MANAGER_TLS = check_tls_mode(os.environ.get('LABRAD_TLS', 'starttls'))
+MANAGER_TLS = check_tls_mode(os.environ.get('LABRAD_TLS', DEFAULT_TLS))
 MANAGER_PORT_TLS = int(os.environ.get('LABRAD_TLS_PORT', 7643))
 MANAGER_HOST = os.environ.get('LABRADHOST', 'localhost')
 PASSWORD = os.environ.get('LABRADPASSWORD', None)

--- a/labrad/crypto.py
+++ b/labrad/crypto.py
@@ -6,8 +6,14 @@ import re
 
 
 try:
-    from twisted.internet import ssl
-    TLS = True
+    import twisted
+    if int(twisted.__version__.split('.')[0]) >= 14:
+        from twisted.internet import ssl
+        TLS = True
+    else:
+        logging.warning("Twisted version >= 14.0.0 required for SSL support. "
+                        "Older versions don't support the platform CA roots.")
+        TLS = False
 except ImportError:
     logging.warning('pyOpenSSL not found. Without encryption you will only be '
                     'able to connect to the labrad manager on localhost.')


### PR DESCRIPTION
I finished tracking down the twisted version issue from #178.  The API we use to handle certificate loading in crypto.py is only supported in twisted 14.0.0 and later, which has been out for a while, but twisted 13 is still default on a lot of systems (particularly, Ubuntu 14.04 LTS).  The TLS support in older versions of twisted requires you to provide the CA root certificates yourself, or use the default behavior which is not to validate SSL certificates.  Twisted 14 supports loading the platform trusted roots.  Rather than disable validation or try to implement trust roots, this patch simply disables TLS with a warning if run on older versions of twisted.  Combined with #180, this should help avoid unexplained problems when people download versions supporting TLS.