### PR TITLE
Fix duplicate short form for tls and syslog node options

### DIFF
--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -934,7 +934,7 @@ class NodeOptions(usage.Options):
             ['name', 'n', util.getNodeName(), 'Node name.'],
             ['port', 'p', C.MANAGER_PORT, 'Manager port.'],
             ['host', 'h', C.MANAGER_HOST, 'Manager location.'],
-            ['tls', 's', C.MANAGER_TLS,
+            ['tls', '', C.MANAGER_TLS,
              'TLS mode for connecting to manager (on/starttls/off)'],
             ['logfile', 'l', None, 'Enable logging to a file'],
             ['syslog_socket', 'x', None,


### PR DESCRIPTION
Fixes #190 

The `tls` option and `syslog` flag had the same short form `s`. This drops the short form for the `tls` option to remove the ambiguity. I much prefer the explicitness of saying `--tls=blah` anyway. With this change the help text reads:

```
$ python -m labrad.node --help
Usage: __main__.py [options]
Options:
  -s, --syslog          Enable syslog
  -v, --verbose         Enable debug output
  -n, --name=           Node name. [default: localhost]
  -p, --port=           Manager port. [default: 7682]
  -h, --host=           Manager location. [default: localhost]
      --tls=            TLS mode for connecting to manager (on/starttls/off)
                        [default: off]
  -l, --logfile=        Enable logging to a file
  -x, --syslog_socket=  Override default syslog socket. Absolute path or
                        host[:port]
      --version         Display Twisted version and exit.
      --help            Display this help and exit.

Run a node service for controlling other labrad servers.

This files makes it possible to run the node as an executable module:

`python -m labrad.node`
```