### PR TITLE
Refactor protocol to share connection logic between server and client

### DIFF
--- a/labrad/client.py
+++ b/labrad/client.py
@@ -512,9 +512,9 @@ class Client(HasDynamicAttrs):
         return self._backend.connected
 
     def connect(self, host, port=None, timeout=C.TIMEOUT, password=None,
-                tls=C.MANAGER_TLS):
+                tls_mode=C.MANAGER_TLS):
         self._backend.connect(host, port=port, timeout=timeout,
-                              password=password, tls=tls)
+                              password=password, tls_mode=tls_mode)
 
     def disconnect(self):
         self._backend.disconnect()

--- a/labrad/constants.py
+++ b/labrad/constants.py
@@ -24,11 +24,11 @@ import labrad.crypto
 
 DEFAULT_TLS = 'starttls' if labrad.crypto.TLS else 'off'
 
-def check_tls_mode(tls):
+def check_tls_mode(tls_mode):
     """Check that provided tls mode is valid and convert to canonical form.
 
     Args:
-        tls (string): One of 'on', 'off', 'starttls', or 'starttls-force'.
+        tls_mode (string): One of 'on', 'off', 'starttls', or 'starttls-force'.
             If 'on', we use TLS for the initial session establishment.
             If 'off', no TLS is used (for connecting to a legacy manager that
             does not support TLS). If 'starttls', the connection is initially
@@ -43,11 +43,11 @@ def check_tls_mode(tls):
     Raises:
         ValueError: an invalid tls mode was specified
     """
-    tls = tls.lower()
-    if tls not in ['on', 'off', 'starttls', 'starttls-force']:
+    tls_mode = tls_mode.lower()
+    if tls_mode not in ['on', 'off', 'starttls', 'starttls-force']:
         raise ValueError("tls mode must be one of 'on', 'off', 'starttls', or "
-                         "'starttls-force'. got: '{}'".format(tls))
-    return tls
+                         "'starttls-force'. got: '{}'".format(tls_mode))
+    return tls_mode
 
 # defaults for the labrad manager
 MANAGER_ID = 1

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -20,47 +20,21 @@ Base classes for building asynchronous, context- and request- aware
 servers with labrad.
 """
 
-import getpass
 from datetime import datetime
 from operator import attrgetter
 import traceback
 
-from twisted.application import service, internet
 from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.internet.error import ConnectionDone
-from twisted.internet.protocol import ClientFactory
+from twisted.internet.error import ConnectionDone, ConnectionLost
 from twisted.python import failure, log
-from twisted.python.components import registerAdapter
 from twisted.plugin import IPlugin
 from zope.interface import implements
 
-from labrad import constants as C, crypto, types as T, util
+from labrad import constants as C, types as T, util
 from labrad.decorators import setting
-from labrad.protocol import LabradProtocol
-from labrad.interfaces import ILabradServer, IClientAsync
+from labrad.interfaces import IClientAsync
 
-class ServerProtocol(LabradProtocol):
-    """Standard protocol for labrad servers.
-
-    Most of the server-specific customization goes in the factory,
-    not this protocol class.
-    """
-    def connectionMade(self):
-        LabradProtocol.connectionMade(self)
-        self.factory._connectionMade(self)
-
-    @inlineCallbacks
-    def requestReceived(self, source, context, request, records):
-        """Handle incoming requests."""
-        try:
-            response = yield self.factory.handleRequest(source, context, records)
-            self.sendPacket(source, context, -request, response)
-        except Exception as e:
-            # this will only happen if there was a problem while sending,
-            # which usually means a problem flattening the response into
-            # a valid LabRAD packet
-            self.sendPacket(source, context, -request, [(0, e)])
 
 class Signal(object):
     """A Signal object is a simple publish/subscribe messaging primitive.
@@ -206,12 +180,11 @@ class Context(object):
         self.expired = True
 
 
-class LabradServer(ClientFactory):
+class LabradServer(object):
     """A generic LabRAD server."""
 
-    implements(IPlugin, ILabradServer)
+    implements(IPlugin)
 
-    protocol = ServerProtocol
     sendTracebacks = True
     prioritizeWrites = False
 
@@ -228,28 +201,9 @@ class LabradServer(ClientFactory):
         self.signals = []
         self.contexts = {}
 
-    def configure_tls(self, host, tls):
-        """Configure TLS options for this server's connection to labrad.
-
-        Must be called before we actually initiate a network connection, e.g.
-        before this server instance is passed to one of the reactor.connect*
-        methods.
-
-        Args:
-            host (string): The remote hostname of the manager we are connecting
-                to. This will be used to validate the hostname of the
-                certificate presented by the manager.
-            tls (string): One of 'on', 'off' or 'starttls'. Note that if
-                tls == 'on', the connection should be initiated with
-                reactor.connectSSL, while if tls == 'off' or tls == 'starttls'
-                then reactor.connectTCP should be used instead.
-        """
-        self._remote_host = host
-        self._tls_mode = C.check_tls_mode(tls)
-
     # request handling
     @inlineCallbacks
-    def handleRequest(self, source, context, records):
+    def request_handler(self, source, context, records):
         """Handle an incoming request.
 
         If this is a new context, we create a context object and a lock
@@ -366,39 +320,31 @@ class LabradServer(ClientFactory):
         self.signals.remove(signal)
         return self.removeSetting(signal, packet)
 
-    # Network events
-    # these methods are called by network events from twisted
     @inlineCallbacks
-    def _connectionMade(self, protocol):
-        """Login as a server after connecting to LabRAD."""
+    def startup(self, protocol):
+        """Start this server using the given protocol connection.
+
+        Identifies this server to the manager, creates an async wrapper for the
+        protocol connection, and then runs initialization callbacks for this
+        server.
+
+        Args:
+            protocol (labrad.protocol.LabradProtocol): A protocol connection
+                to the labrad manager, as returned by labrad.protocol.connect.
+                This protocol must have been authenticated prior to calling
+                startup.
+
+        Returns:
+            twisted.internet.defer.Deferred(None): A deferred that will fire
+            once startup is complete.
+        """
         try:
-            addr = protocol.transport.getPeer()
-            is_local_connection = util.is_local_connection(protocol.transport)
-            log.msg('Connected to {}:{}'.format(addr.host, addr.port))
-            if ((self._tls_mode == 'starttls-force') or
-                (self._tls_mode == 'starttls' and not is_local_connection)):
-                log.msg('Manager is remote ({}). Starting TLS.'.format(addr.host))
-                host = self._remote_host
-                try:
-                    yield protocol.sendRequest(C.MANAGER_ID, [(1L, ('STARTTLS', host))])
-                except Exception as e:
-                    raise Exception(
-                        'Failed sending STARTTLS command to server. You should '
-                        'update the manager and configure it to support '
-                        'encryption or else disable encryption for clients. See '
-                        'https://github.com/labrad/pylabrad/blob/master/CONFIG.md.'
-                        'Error: {}'.format(e))
-                protocol.transport.startTLS(crypto.tls_options(host))
-                try:
-                    yield protocol.sendRequest(C.MANAGER_ID, [(2L, 'PING')])
-                except Exception as e:
-                    raise Exception('STARTTLS failed. Check that manager certificates are accepted.')
-            self.mgr_host, self.mgr_port = addr.host, addr.port
             name = getattr(self, 'instanceName', self.name)
-            yield protocol.loginServer(self._getPassword(), name,
-                                       self.description, self.notes)
-            self.password = protocol.password
+            yield protocol.loginServer(name, self.description, self.notes)
             self._cxn = protocol
+            self.ID = protocol.ID
+            protocol.request_handler = self.request_handler
+            protocol.onDisconnect().addBoth(self._connection_lost)
             self.client = IClientAsync(protocol)
             yield self.client._init()
             yield self._initServer()
@@ -409,14 +355,8 @@ class LabradServer(ClientFactory):
             traceback.print_exc()
             self.disconnect(e)
 
-    def _getPassword(self):
-        if getattr(self, 'password', None) is not None:
-            pw = self.password
-        elif C.PASSWORD is not None:
-            pw = C.PASSWORD
-        else:
-            pw = getpass.getpass('Enter LabRAD password: ')
-        return pw
+    # Network events
+    # these methods are called by network events from twisted
 
     @inlineCallbacks
     def _initServer(self):
@@ -475,11 +415,7 @@ class LabradServer(ClientFactory):
             if hasattr(self, '_shutdownID'):
                 reactor.removeSystemEventTrigger(self._shutdownID)
 
-    def clientConnectionFailed(self, connector, reason):
-        """Called when we fail to establish a network to LabRAD."""
-        self.onStartup.errback(reason)
-
-    def clientConnectionLost(self, connector, reason):
+    def _connection_lost(self, reason):
         """Called when the network connection to LabRAD is lost.
 
         This could happen either because there was an error and the
@@ -489,7 +425,7 @@ class LabradServer(ClientFactory):
         if not self.started:
             self.onStartup.errback(reason)
         else:
-            if self.stopping and reason.check(ConnectionDone):
+            if self.stopping and (reason is None or reason.check(ConnectionDone, ConnectionLost)):
                 self.onShutdown.callback()
             else:
                 self.onShutdown.errback(reason)
@@ -618,16 +554,4 @@ class LabradServer(ClientFactory):
 
     def log(self, *messages):
         self.onLog((datetime.now(), messages))
-
-
-class LabradService(internet.TCPClient):
-    def __init__(self, server):
-        internet.TCPClient.__init__(self, server.host, server.port, server)
-        self.server = server
-        self.setName(server.name)
-        self.onStartup = server.onStartup
-        self.onShutdown = server.onShutdown
-
-registerAdapter(LabradService, ILabradServer, service.IService)
-
 

--- a/labrad/test/test_backends.py
+++ b/labrad/test/test_backends.py
@@ -8,19 +8,19 @@ from labrad.errors import LoginFailedError
 class AsyncoreBackendTests(unittest.TestCase):
     def testConnection(self):
         cxn = backend.AsyncoreConnection()
-        cxn.connect(tls='off')
+        cxn.connect(tls_mode='off')
         self.assertTrue(cxn.loop.is_alive())
         cxn.disconnect()
         self.assertFalse(cxn.loop.is_alive())
 
     def testBadHostExceptions(self):
         cxn = backend.AsyncoreConnection()
-        self.assertRaises(LoginFailedError, cxn.connect, host='bad.host.com', timeout=1, tls='off')
+        self.assertRaises(LoginFailedError, cxn.connect, host='bad.host.com', timeout=1, tls_mode='off')
         self.assertFalse(hasattr(cxn, 'loop'))
 
     def testBadPasswordException(self):
         cxn = backend.AsyncoreConnection()
-        self.assertRaises(LoginFailedError, cxn.connect, password='bad password', timeout=1, tls='off')
+        self.assertRaises(LoginFailedError, cxn.connect, password='bad password', timeout=1, tls_mode='off')
         self.assertFalse(cxn.connected)
         # event loop should terminate
         cxn.loop.join(1)
@@ -28,7 +28,7 @@ class AsyncoreBackendTests(unittest.TestCase):
 
     def testRequestCancellation(self):
         cxn = backend.AsyncoreConnection()
-        cxn.connect(tls='off')
+        cxn.connect(tls_mode='off')
         cxn.sendRequest(1, [(1L, None)]).wait()
         future = cxn.sendRequest(1, [(1L, None)])
         self.assertTrue(cxn.loop.is_alive())
@@ -47,7 +47,7 @@ class AsyncoreBackendTests(unittest.TestCase):
         )
 
         cxn = backend.AsyncoreConnection()
-        cxn.connect(tls='off')
+        cxn.connect(tls_mode='off')
         self.assertTrue(cxn.loop.is_alive())
         cxn.sendRequest(1, [(1L, None)]).wait()
         cxn.cxn.queue.put(badPacket)

--- a/labrad/test/test_tls.py
+++ b/labrad/test/test_tls.py
@@ -77,7 +77,7 @@ def run_manager(tls_required, port=7778, tls_port=7779, startup_timeout=20):
             start = time.time()
             while True:
                 try:
-                    labrad.connect(port=tls_port, tls='on')
+                    labrad.connect(port=tls_port, tls_mode='on')
                 except Exception, e:
                     last_error = e
                 else:
@@ -97,17 +97,17 @@ def run_manager(tls_required, port=7778, tls_port=7779, startup_timeout=20):
 
 def test_connect_with_starttls():
     with run_manager(tls_required=True) as m:
-        with labrad.connect(port=m.port, tls='starttls-force') as cxn:
+        with labrad.connect(port=m.port, tls_mode='starttls-force') as cxn:
             pass
 
 def test_connect_with_optional_starttls():
     with run_manager(tls_required=False) as m:
-        with labrad.connect(port=m.port, tls='off') as cxn:
+        with labrad.connect(port=m.port, tls_mode='off') as cxn:
             pass
 
 def test_connect_with_tls():
     with run_manager(tls_required=True) as m:
-        with labrad.connect(port=m.tls_port, tls='on') as cxn:
+        with labrad.connect(port=m.tls_port, tls_mode='on') as cxn:
             pass
 
 
@@ -117,19 +117,19 @@ def test_connect_with_tls():
 def test_expect_starttls_use_off():
     with run_manager(tls_required=True) as m:
         with pytest.raises(Exception):
-            with labrad.connect(port=m.port, tls='off') as cxn:
+            with labrad.connect(port=m.port, tls_mode='off') as cxn:
                 pass
 
 def test_expect_tls_use_off():
     with run_manager(tls_required=True) as m:
         with pytest.raises(Exception):
-            with labrad.connect(port=m.tls_port, tls='off') as cxn:
+            with labrad.connect(port=m.tls_port, tls_mode='off') as cxn:
                 pass
 
 def test_expect_tls_use_starttls():
     with run_manager(tls_required=True) as m:
         with pytest.raises(Exception):
-            with labrad.connect(port=m.tls_port, tls='off') as cxn:
+            with labrad.connect(port=m.tls_port, tls_mode='off') as cxn:
                 pass
 
 

--- a/labrad/util/__init__.py
+++ b/labrad/util/__init__.py
@@ -367,8 +367,6 @@ def updateServerOptions(srv, config):
     if hasattr(srv, 'instanceName'):
         srv.instanceName = interpEnvironmentVars(srv.instanceName, env)
 
-    srv.password = config['password']
-
 def runServer(srv, run_reactor=True, stop_reactor=True):
     """Run the given server instance.
 
@@ -381,6 +379,7 @@ def runServer(srv, run_reactor=True, stop_reactor=True):
             server instance shuts down (whether normally or due to an error
             condition. Otherwise, the caller must arrange to call reactor.stop.
     """
+    from labrad import protocol
     from twisted.internet import reactor
 
     config = parseServerOptions(name=srv.name)
@@ -394,14 +393,11 @@ def runServer(srv, run_reactor=True, stop_reactor=True):
     def run(srv):
         host = config['host']
         port = int(config['port'])
-        srv.configure_tls(host, config['tls'])
-        if config['tls'] == 'on':
-            tls_options = crypto.tls_options(host)
-            reactor.connectSSL(host, port, srv, tls_options)
-        else:
-            reactor.connectTCP(host, port, srv)
+        tls_mode = config['tls']
         try:
-            yield srv.onStartup()
+            p = yield protocol.connect(host, port, tls_mode)
+            yield p.authenticate(config['password'])
+            yield srv.startup(p)
             yield srv.onShutdown()
             log.msg('Disconnected cleanly.')
         except Exception as e:
@@ -418,33 +414,28 @@ def runServer(srv, run_reactor=True, stop_reactor=True):
 
 @contextlib.contextmanager
 def syncRunServer(srv, host=C.MANAGER_HOST, port=None, password=None,
-                  tls=C.MANAGER_TLS):
+                  tls_mode=C.MANAGER_TLS):
     """Run a labrad server of the specified class in a synchronous context.
 
     Returns a context manager to be used with python's with statement that
     will yield when the server has started and then shut the server down after
     the context is exited.
     """
+    from labrad import protocol
 
-    tls = C.check_tls_mode(tls)
+    tls_mode = C.check_tls_mode(tls_mode)
 
     if port is None:
-        port = C.MANAGER_PORT_TLS if tls == 'on' else C.MANAGER_PORT
+        port = C.MANAGER_PORT_TLS if tls_mode == 'on' else C.MANAGER_PORT
 
     if password is None:
         password = C.PASSWORD
 
-    srv.password = password
-
     @inlineCallbacks
     def start_server():
-        srv.configure_tls(host, tls)
-        if tls == 'on':
-            tls_options = crypto.tls_options(host)
-            reactor.connectSSL(host, port, srv, tls_options)
-        else:
-            reactor.connectTCP(host, port, srv)
-        yield srv.onStartup()
+        p = yield protocol.connect(host, port, tls_mode)
+        yield p.authenticate(password)
+        yield srv.startup(p)
 
     @inlineCallbacks
     def stop_server():


### PR DESCRIPTION
Labrad servers and clients are both network "clients" in the sense that they make outbound network connections to the manager rather than accepting inbound connections. By refactoring the labrad server class to be just a plain python class rather than a twisted ClientFactory, we can reuse the same connection logic for both labrad clients and servers. This also lets us write the connection logic in a more direct style, where previously much of the server connection logic happened as a side-effect of network callbacks in the Server class which was an instance of ClientFactory.

I have reworked the node to use this new connection style and tested that it still works. I think the logic there is much cleaner with fewer callbacks and more inlineCallbacks.

Note that code which relies on LabradServer being a subclass of ClientFactory will have to be modified after this change. The only instance if that I know if the multi-headed data vault, which runs multiple LabradServer instances as twisted Services. This will have to be changed much as the node has been changed here.