### PR TITLE
Replace custom Future implementation with standard futures lib.

### DIFF
--- a/labrad/concurrent.py
+++ b/labrad/concurrent.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import
+
+import warnings
+
+from concurrent import futures
+
+
+def map_future(src, func, *args, **kw):
+    """Create a future that applies a function to the result of a source future.
+
+    Args:
+        src (concurrent.futures.Future): The future whose result we wish to
+            modify.
+        func (callable): Function to apply to the result of src. This function
+            will be called like func(result, *args, **kw) where result is the
+            value produced by src.
+        args: Positional args to be passed to func.
+        kw: Keyword args to be passed to func.
+
+    Returns:
+        A new Future whose result will be the given function applied to the
+        result of src. If src fails with an exception, or if func raises an
+        exception when called, the error will be propagated to the returned
+        future.
+    """
+    return MappedFuture(src, func, *args, **kw)
+
+
+class MappedFuture(futures.Future):
+    """A Future that receives the result or failure of another Future.
+
+    Args:
+        src (concurrent.future.Future): Source future whose value this future
+            will receive and possibly modify.
+        func (callable | None): Function that will be applied to the result of
+            src before setting it on this Future. This function will be called
+            like func(result, *args, **kw). If None, the result will be passed
+            along unchanged.
+        args: Positional args to be passed to func.
+        kw: Keyword args to be passed to func.
+    """
+    def __init__(self, src, func, *args, **kw):
+        super(MappedFuture, self).__init__()
+        def handle_result(f):
+            if not self.set_running_or_notify_cancel():
+                return
+            if src.cancelled():
+                self.set_exception(futures.CancelledError())
+                return
+            error = src.exception()
+            if error is not None:
+                self.set_exception(error)
+                return
+            try:
+                result = src.result()
+                if func is not None:
+                    result = func(result, *args, **kw)
+                self.set_result(result)
+            except Exception as e:
+                self.set_exception(e)
+        src.add_done_callback(handle_result)
+        self._src = src
+
+    def cancel(self):
+        return super(MappedFuture, self).cancel() and self._src.cancel()
+
+
+class MutableFuture(MappedFuture):
+    """Backwards compatible subclass of concurrent.futures.Future.
+
+    The biggest difference from standard Futures is that the old labrad Future
+    tries to emulate the mutable addCallback interface of twisted Deferreds. To
+    emulate this behavior, we keep a list of callback functions which are used
+    to transform the result of the future when .result() is called.
+
+    We also provide .wait() as an alias for .result(), since the old Future
+    class used the former to get value.
+
+    Note: this class will be removed after users have updated to use the
+        standard Future interface with mapping.
+    """
+    def __init__(self, source):
+        super(MutableFuture, self).__init__(source, None)
+        self._callbacks = []
+        self._done = False
+        self._result = None
+        self._error = None
+
+    def addCallback(self, func, *args, **kw):
+        warnings.warn("addCallback is deprecated; use map_future instead.")
+        self._callbacks.append((func, args, kw))
+
+    def wait(self):
+        """Alias for the result() method; for backwards compatibility."""
+        warnings.warn(".wait() is deprecated; use .result() instead.")
+        return self.result()
+
+    def result(self, timeout=None):
+        if not self._done:
+            self._result = super(MutableFuture, self).result(timeout)
+            self._done = True
+        if self._error is not None:
+            raise self._error
+        while len(self._callbacks):
+            func, args, kw = self._callbacks.pop(0)
+            try:
+                self._result = func(self._result, *args, **kw)
+            except Exception as e:
+                self._error = e
+                raise e
+        return self._result
+
+    def exception(self, timeout=None):
+        if not self._done:
+            self._error = super(MutableFuture, self).exception(timeout)
+            self._done = True
+        return self._error

--- a/labrad/test/test_backends.py
+++ b/labrad/test/test_backends.py
@@ -29,12 +29,12 @@ class AsyncoreBackendTests(unittest.TestCase):
     def testRequestCancellation(self):
         cxn = backend.AsyncoreConnection()
         cxn.connect(tls_mode='off')
-        cxn.sendRequest(1, [(1L, None)]).wait()
+        cxn.sendRequest(1, [(1L, None)]).result()
         future = cxn.sendRequest(1, [(1L, None)])
         self.assertTrue(cxn.loop.is_alive())
         cxn.disconnect()
         self.assertFalse(cxn.loop.is_alive())
-        self.assertRaises(Exception, future.wait)
+        self.assertRaises(Exception, future.result)
 
     def testConnectionDrop(self):
         badPacket = (
@@ -49,13 +49,13 @@ class AsyncoreBackendTests(unittest.TestCase):
         cxn = backend.AsyncoreConnection()
         cxn.connect(tls_mode='off')
         self.assertTrue(cxn.loop.is_alive())
-        cxn.sendRequest(1, [(1L, None)]).wait()
+        cxn.sendRequest(1, [(1L, None)]).result()
         cxn.cxn.queue.put(badPacket)
         cxn.cxn.queue.put(badPacket) # this will cause the manager to drop us...
         # we send a request in a subfunction because the exception can be raised
         # either in the sendRequest call or in the wait call, depending on timing
         def doRequest():
-            cxn.sendRequest(1, [(1L, None)]).wait()
+            cxn.sendRequest(1, [(1L, None)]).result()
         self.assertRaises(Exception, doRequest)
         self.assertRaises(Exception, doRequest)
 

--- a/labrad/test/test_client.py
+++ b/labrad/test/test_client.py
@@ -64,9 +64,24 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(len(resp), 4)
 
         # single setting with delayed response
+        resp = pts.echo.future(TEST_STR)
+        resp = resp.result()
+        self.assertEqual(resp, TEST_STR)
+
+        # allow .wait() for backwards compatibility
+        resp = pts.echo.future(TEST_STR)
+        resp = resp.wait()
+        self.assertEqual(resp, TEST_STR)
+
+        # allow calling with wait=False for backwards compatibility
+        resp = pts.echo(TEST_STR, wait=False)
+        resp = resp.result()
+        self.assertEqual(resp, TEST_STR)
+
         resp = pts.echo(TEST_STR, wait=False)
         resp = resp.wait()
         self.assertEqual(resp, TEST_STR)
+
 
     def testCompoundPacket(self):
         pts = self._get_tester()
@@ -98,6 +113,25 @@ class ClientTests(unittest.TestCase):
         # test packet mutation by key
         pkt2['two'] = TEST_STR
         resp = pkt2.send()
+        self.assertEqual(resp.two, TEST_STR)
+
+        # send packet asynchronously
+        resp = pkt2.send_future()
+        resp = resp.result()
+        self.assertEqual(resp.two, TEST_STR)
+
+        # allow calling .wait() for backwards compatibility
+        resp = pkt2.send_future()
+        resp = resp.wait()
+        self.assertEqual(resp.two, TEST_STR)
+
+        # allow sending with wait=False for backwards compatibility
+        resp = pkt2.send(wait=False)
+        resp = resp.result()
+        self.assertEqual(resp.two, TEST_STR)
+
+        resp = pkt2.send(wait=False)
+        resp = resp.wait()
         self.assertEqual(resp.two, TEST_STR)
 
     def testTupleKeys(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy >= 1.9.1
+futures >= 3.0.4
 twisted >= 14.0.0
 pyOpenSSL >= 0.13


### PR DESCRIPTION
The `futures` package is a backport of standard lib futures from python3. We use a subclass of `Future` from this library that is backwards compatible with the old implementation, but deprecate the `.wait()` method. In addition, we change the way Futures are used when calling settings and sending packets. Previously, these could be passed an extra 'wait' argument to control whether to block until the result was available or to return a Future. While this usage is still supported, it will now result in deprecation warnings. Instead, we provide separate `.future` and `.send_future` methods for settings and packets, respectively.