### PR TITLE
Allow numpy int array to be flattened to labrad *v

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -351,5 +351,11 @@ class LabradTypesTests(unittest.TestCase):
         self.assertEquals(T.unflatten(foo.bytes, 'y'), 'foo bar')
         self.assertEquals(T.unflatten(*T.flatten('foo bar', ['y'])), 'foo bar')
 
+    def testFlattenIntArrayToValueArray(self):
+        x = np.array([1, 2, 3, 4], dtype='int64')
+        flat = T.flatten(x, '*v')
+        y = T.unflatten(*flat)
+        self.assertTrue(np.all(x == y))
+
 if __name__ == "__main__":
     unittest.main()

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -1249,8 +1249,9 @@ class LRList(LRType):
                 # Make sure it is unflattened so endian conversion happens
                 L.aslist
         if isinstance(L, ndarray):
-            if self.elem <= LRValue() and self.elem.unit != '':
-                msg = "Can't flatten ndarray to %s"%(self,)
+            if (self.elem <= LRValue() and
+                    not (self.elem.unit is None or self.elem.unit == '')):
+                msg = "Can't flatten ndarray to {}".flatten(self)
                 raise TypeError(msg)
             return self.__flatten_array__(L, endianness)
         if isinstance(L, U.ValueArray):


### PR DESCRIPTION
Fixes #216
