### PR TITLE
Cache passwords per manager based on host and port

### DIFF
--- a/labrad/backend.py
+++ b/labrad/backend.py
@@ -36,6 +36,9 @@ class BaseConnection(object):
                 password=None, tls_mode=C.MANAGER_TLS):
         self.host = host
         self.port = port
+        self.timeout = timeout
+        self.tls_mode = tls_mode
+        self.password = password
         self.ID = self._connect(password, timeout, tls_mode=tls_mode)
 
     @property
@@ -45,6 +48,14 @@ class BaseConnection(object):
     def disconnect(self):
         if self.connected:
             self._disconnect()
+
+    def spawn(self):
+        """Start a new independent backend connection to the same manager."""
+        cls = self.__class__
+        inst = cls(name=self.name)
+        inst.connect(host=self.host, port=self.port, timeout=self.timeout,
+                     password=self.password, tls_mode=self.tls_mode)
+        return inst
 
     def _connect(self, password=None, timeout=None, tls_mode=C.MANAGER_TLS):
         """Implemented by subclass"""

--- a/labrad/client.py
+++ b/labrad/client.py
@@ -456,7 +456,7 @@ class Client(HasDynamicAttrs):
             return []
         return self._mgr.getServersList()
 
-    _staticAttrs = ['servers', 'connect', 'disconnect', 'context']
+    _staticAttrs = ['servers', 'connect', 'disconnect', 'context', 'spawn']
     _wrapAttr = ServerWrapper
 
     @property
@@ -495,6 +495,10 @@ class Client(HasDynamicAttrs):
 
     def context(self):
         return self._backend.context()
+
+    def spawn(self):
+        """Start a new independent connection to the same manager."""
+        return Client(self._backend.spawn())
 
     def _send(self, target, records, *args, **kw):
         """Send a packet over this connection."""

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -877,7 +877,7 @@ def makeService(options):
     name = options['name']
     host = options['host']
     port = int(options['port'])
-    password = labrad.support.getPassword()
+    password = labrad.support.get_password(host, port)
     tls_mode = C.check_tls_mode(options['tls'])
     return Node(name, host, port, password, tls_mode)
 

--- a/labrad/support.py
+++ b/labrad/support.py
@@ -15,13 +15,64 @@ from labrad import constants
 def getNodeName():
     return os.environ.get('LABRADNODE', socket.gethostname().lower())
 
-def getPassword():
-    """Get a password, either from the environment, or the command line."""
-    if constants.PASSWORD is not None:
-        pw = constants.PASSWORD
+
+# cache of passwords, keyed by host name and port number
+_password_cache = {}
+
+
+def get_password(host=None, port=None, prompt=True):
+    """Get a password from the environment, cache, or command line prompt.
+
+    To add a password to the cache, use the cache_password function.
+
+    Args:
+        host (str or None): The manager host we want to connect to.
+        port (int or None): The manager port we want to connect to.
+        prompt (bool): Whether to prompt the user to enter a password at the
+            command line if none is found in the cache or environment vars.
+
+    Returns:
+        (str or None): The password for the given host and port. If we did not
+        find a password in the cache or environment vars and prompt was False,
+        will return None.
+    """
+    # create cache entries for the environment password if needed
+    if not _password_cache and constants.PASSWORD is not None:
+        cache_password(host=constants.MANAGER_HOST,
+                       port=constants.MANAGER_PORT,
+                       password=constants.PASSWORD)
+        cache_password(host=constants.MANAGER_HOST,
+                       port=constants.MANAGER_PORT_TLS,
+                       password=constants.PASSWORD)
+
+    if host is None:
+        host = constants.MANAGER_HOST
+    if port is None:
+        port = constants.MANAGER_PORT
+    addr = (host, port)
+    if addr in _password_cache:
+        pw = _password_cache[addr]
+    elif prompt:
+        msg = 'Enter LabRAD password ({}:{}): '.format(host, port)
+        pw = getpass.getpass(msg)
     else:
-        pw = getpass.getpass('Enter LabRAD password: ')
+        pw = None
     return pw
+
+
+def cache_password(host, port, password):
+    """Add a password to the cache, for the given host and port.
+
+    Cached passwords will be used for subsequent labrad connections to the same
+    host and port. See the get_password function.
+
+    Args:
+        host (str): The manager host for this password.
+        port (int): The manager port for this password.
+        password (str): The password to cache.
+    """
+    _password_cache[host, port] = password
+
 
 ALLOWED = 'abcdefghijklmnopqrstuvwxyz1234567890_'
 FIRST = 'abcdefghijklmnopqrstuvwxyz_'

--- a/labrad/util/__init__.py
+++ b/labrad/util/__init__.py
@@ -23,7 +23,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.threads import blockingCallFromThread
 from twisted.python import log, reflect, util
 
-from labrad import constants as C, crypto, thread
+from labrad import constants as C, crypto, support, thread
 from labrad.support import getNodeName
 from labrad.util.unwrap import unwrap
 
@@ -330,7 +330,7 @@ def parseServerOptions(name, exit_on_failure=True, options=None):
             ['node', 'd', getNodeName(), 'Node name.'],
             ['host', 'h', C.MANAGER_HOST, 'Manager location.'],
             ['port', 'p', None, 'Manager port.', int],
-            ['password', 'w', C.PASSWORD, 'Login password.'],
+            ['password', 'w', None, 'Login password.'],
             ['tls', 's', C.MANAGER_TLS,
              'TLS mode for connecting to manager (on/starttls/off)']]
 
@@ -338,6 +338,10 @@ def parseServerOptions(name, exit_on_failure=True, options=None):
     config['tls'] = C.check_tls_mode(config['tls'])
     try:
         config.parseOptions(options=options)
+        if config['password'] is None:
+            config['password'] = support.get_password(host=config['host'],
+                                                      port=config['port'],
+                                                      prompt=False)
         if config['port'] is None:
             tls_on = config['tls'] == 'on'
             config['port'] = C.MANAGER_PORT_TLS if tls_on else C.MANAGER_PORT


### PR DESCRIPTION
Adds a cache where we separately store the passwords for managers on different hosts/ports. In addition, the `LABRADPASSWORD` environment variable is only applied to the default manager referenced by the environment variables `LABRADHOST` and `LABRADPORT`. This makes it easier to work in a multi-manager setting when different managers may require different credentials.

@JulianSKelly 