### PR TITLE
Add method to get flattenable representation of a packet.

### DIFF
--- a/labrad/stream.py
+++ b/labrad/stream.py
@@ -53,8 +53,8 @@ def flattenPacket(target, context, request, records, endianness='>'):
     else:
         kw = {'endianness': endianness}
         data = ''.join(flattenRecord(*rec, **kw) for rec in records)
-    return PACKET_TYPE.__flatten__((context, request, target, data),
-        endianness)[0]
+    flat = PACKET_TYPE.flatten((context, request, target, data), endianness)
+    return flat.bytes
 
 def flattenRecords(records, endianness='>'):
     kw = {'endianness': endianness}
@@ -62,13 +62,12 @@ def flattenRecords(records, endianness='>'):
 
 def flattenRecord(ID, data, types=[], endianness='>'):
     """Flatten a piece of data into a record with datatype and property."""
-    if isinstance(data, T.FlatData):
-        s, t = data
-    else:
-        try:
-            s, t = T.flatten(data, types, endianness)
-        except T.FlatteningError as e:
-            e.msg = e.msg + "\nSetting ID %s." % (ID,)
-            raise
-    return RECORD_TYPE.__flatten__((ID, str(t), str(s)), endianness)[0]
+    try:
+        flat = T.flatten(data, types, endianness)
+    except T.FlatteningError as e:
+        e.msg = e.msg + "\nSetting ID %s." % (ID,)
+        raise
+    flat_record = RECORD_TYPE.flatten((ID, str(flat.tag), str(flat.bytes)),
+                                      endianness)
+    return flat_record.bytes
 

--- a/labrad/support.py
+++ b/labrad/support.py
@@ -145,7 +145,12 @@ class PrettyMultiDict(MultiDict):
         return '\n'.join(sorted(self.keys()))
 
 
-PacketRecord = collections.namedtuple('PacketRecord', ['ID', 'data', 'tag', 'flat', 'key'])
+PacketRecord = collections.namedtuple('PacketRecord', ['ID', 'data', 'tag',
+                                                       'flat', 'key', 'name'])
+
+
+FlatPacket = collections.namedtuple('FlatPacket', ['context', 'name',
+                                                   'records'])
 
 
 class PacketResponse(object):

--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -357,5 +357,59 @@ class LabradTypesTests(unittest.TestCase):
         y = T.unflatten(*flat)
         self.assertTrue(np.all(x == y))
 
+    def testCanFlattenFlatData(self):
+        x = ('this is a test', -42, [False, True])
+        flat = T.flatten(x)
+        self.assertEquals(T.parseTypeTag(flat.tag), T.parseTypeTag('si*b'))
+        flat2 = T.flatten(x)
+        self.assertEquals(flat2, flat)
+        flat3 = T.flatten(x, 'si*b')
+        self.assertEquals(flat3, flat)
+        with self.assertRaises(T.FlatteningError):
+            T.flatten(x, 'sv')
+
+    def testCanFlattenListOfPartialFlatData(self):
+        x1 = ('this is a test', -42, [False, True])
+        piece1 = T.flatten(x1)
+        x2 = ('this is also a test', -43, [False, True, True, True])
+        piece2 = T.flatten(x2)
+
+        not_flattened = [x1, x2]
+        partially_flattened = [piece1, piece2]
+        tag = '*(si*b)'
+
+        expected = T.flatten(not_flattened)
+
+        flat1 = T.flatten(partially_flattened)
+        self.assertEquals(flat1, expected)
+
+        flat2 = T.flatten(partially_flattened, tag)
+        self.assertEquals(flat2, expected)
+
+        with self.assertRaises(T.FlatteningError):
+            T.flatten(partially_flattened, '*(si)')
+
+    def testCanFlattenClusterOfPartialFlatData(self):
+        x1 = ('this is a test', -42, [False, True])
+        piece1 = T.flatten(x1)
+        x2 = ('this is also a test', -43, [False, True, True, True])
+        piece2 = T.flatten(x2)
+
+        not_flattened = (('1', x1), ('2', x2, False))
+        partially_flattened = (('1', piece1), ('2', piece2, False))
+        tag = '((s(si*b)) (s(si*b)b))'
+
+        expected = T.flatten(not_flattened)
+
+        flat1 = T.flatten(partially_flattened)
+        self.assertEquals(flat1, expected)
+
+        flat2 = T.flatten(partially_flattened, tag)
+        self.assertEquals(flat2, expected)
+
+        with self.assertRaises(T.FlatteningError):
+            T.flatten(partially_flattened, '*(s(si*b))')
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/labrad/wrappers.py
+++ b/labrad/wrappers.py
@@ -21,8 +21,9 @@ from types import MethodType
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from labrad import constants as C, crypto, manager, protocol, types as T, util
-from labrad.support import indent, mangle, extractKey, MultiDict, PacketRecord, PacketResponse, getPassword, hexdump
+from labrad import constants as C, manager, protocol, types as T
+from labrad.support import (indent, mangle, extractKey, MultiDict, PacketRecord,
+                            PacketResponse, hexdump)
 
 
 class AsyncSettingWrapper(object):
@@ -128,7 +129,8 @@ class AsyncPacketWrapper(object):
                 elif len(args) == 1:
                     args = args[0]
                 flat = T.flatten(args, tag)
-                rec = PacketRecord(ID=setting.ID, data=args, tag=tag, flat=flat, key=key)
+                rec = PacketRecord(ID=setting.ID, data=args, tag=tag, flat=flat,
+                                   key=key, name=setting.name)
                 self._packet.append(rec)
                 return self
             wrapped.name = setting.name


### PR DESCRIPTION
As we build packets we use type information on settings to flatten data to types appropriate for those settings. In some situations, we would like to turn this packet data into a structure that can itself be flattened and sent via labrad, for example to be forwarded by another server to the actual target server. In order to do this, we need to be able to handle flattening structures some of whose parts have already been flattened.

@ejeffrey 