### PR TITLE
Do not modify exceptions thrown during server/client login

### DIFF
--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -363,10 +363,7 @@ class LabradProtocol(protocol.Protocol):
     @inlineCallbacks
     def _doLogin(self, *ident):
         # send identification
-        try:
-            resp = yield self.sendRequest(C.MANAGER_ID, [(0L, (1L,) + ident)])
-        except Exception:
-            raise errors.LoginFailedError('Bad identification (Server of same name already running?)')
+        resp = yield self.sendRequest(C.MANAGER_ID, [(0L, (1L,) + ident)])
         self.ID = resp[0][1] # get assigned ID
 
 


### PR DESCRIPTION
The scalabrad manager returns an understandable error message in the case where a server of the same name is already running, so this is not needed anymore. In addition, this masks failures that could be happening for other reasons, so it's best to just let the underlying error propagate. (If only we had [exception chaining](https://www.python.org/dev/peps/pep-3134/) like in python 3...)