### PR TITLE
U/ejeffrey/late unflatten

### DIFF
--- a/labrad/backend.py
+++ b/labrad/backend.py
@@ -380,7 +380,7 @@ class AsyncoreProtocol(asyncore.dispatcher):
         data = self.recv(4096)
         self.stream.send(data)
 
-    def handleResponse(self, _source, _context, request, records):
+    def handleResponse(self, _source, _context, request, flat_records):
         n = -request # reply has request number negated
         if n not in self.requests:
             # probably a response for a request that has already
@@ -390,6 +390,7 @@ class AsyncoreProtocol(asyncore.dispatcher):
         future = self.requests[n]
         del self.requests[n]
         self.pool.add(n)
+        records = [(ID, flat_data.unflatten()) for ID, flat_data in flat_records]
         errors = [r[1] for r in records if isinstance(r[1], Exception)]
         if errors:
             # fail on the first error

--- a/labrad/client.py
+++ b/labrad/client.py
@@ -46,6 +46,9 @@ class SettingWrapper(object):
     method. Calling this object directly will send a request and block until
     the result is available. Calling the .future method will send a request and
     return a future with which to get the result later.
+
+    The keyword argument unflatten=False will suppress the normal unflattening
+    and return a FlatData object.
     """
     def __init__(self, server, name, pyName, ID):
         self.name = self.__name__ = self._labrad_name = name
@@ -320,7 +323,10 @@ class PacketWrapper(HasDynamicAttrs):
         self._kw = kw
 
     def send(self, wait=True, **kw):
-        """Send this packet to the server and wait for the result."""
+        """Send this packet to the server and wait for the result.
+
+        Using the keyword argument unflatten=False will suppress the
+        default unflattening and return FlatData objects"""
         if not wait:
             warnings.warn("Sending packets with wait=False is deprecated. "
                           "Use packet.send_future(...) instead.")

--- a/labrad/decorators.py
+++ b/labrad/decorators.py
@@ -21,202 +21,174 @@ Decorators that help in creating LabRAD servers.
 
 from __future__ import absolute_import
 
-from functools import wraps
-from inspect import getargspec
+import functools
+import inspect
+import itertools
+import types
 
-from twisted.internet.defer import inlineCallbacks
+import twisted.internet.defer as defer
 
 from labrad import types as T, util
-
-def _isGenerator(f):
-    """Check to see whether f is a generator.
-
-    See the documentation on code objects at:
-    http://docs.python.org/ref/types.html
-    """
-    return bool(f.func_code.co_flags & 0x20)
 
 def _product(lists):
     """Return the cartesian product of a list of lists."""
     if not len(lists): return [[]]
     return [[h] + t for h in lists[0] for t in _product(lists[1:])]
 
+def setting(lr_ID, lr_name=None, returns=[], unflatten=True, **params):
+    """Decorator to turn a class method into a remotely accessible setting.
+
+    This just creates a Setting class object which does the actual business.
+    """
+    def decorator(func):
+        return Setting(func, lr_ID, lr_name, returns, unflatten, **params)
+    return decorator
+
 class Setting(object):
-    def __init__(self, func):
+    """Represents a single setting within a Server object.
+    """
+    def __init__(self, func, lr_ID, lr_name, returns, unflatten, **params):
+        """Setting constructor
+        Args:
+
+            func (callable):   Function to implement the setting.
+            lr_ID (int):       The ID number of the setting used in the labrad
+                               protocol
+            lr_name (str):     The setting name.  By default, this is derived
+                               from the function name.
+            returns:           The labrad type tag or list of tags the setting
+                               returns
+            unflatten (bool):  Request automatic unflattening of incoming data.
+                               (default True)
+            **params:          Additional keyword arguments indicate arguments
+                               to the setting.  Each keyword should be a string
+                               matching one of the formal parameters of func,
+                               while the value is the type tag or list of tags
+                               accepted by that parameter.
+
+        If unflattening is requested, pylabrad will use the default unflattening
+        for the data.  Otherwise, arguments will receive FlatData objects.  If
+        there are multiple arguments, the top-level tuple will still be
+        unpacked."""
+
         self.func = func
+        self.ID = lr_ID
+        self.name = lr_name or func.__name__
+        self.returns = [returns] if isinstance(returns, basestring) else returns
+        self.isSetting = True
+        self.unflatten = unflatten
+        self.description, self.notes = util.parseSettingDoc(func.__doc__)
+        self.__doc__ = "Setting wrapper for {}\n\n{}".format(func.__name__, func.__doc__)
+        
+        ###
+        # We need to validate the arguments.  Things we need to checks:
+        #
+        # 1) All parameters must match function arguments
+        # 2) Function arguments with no specified parameter default to '?'
+        # 3) The empty tag '' is only allowd on the first argument, and only
+        #    if all other arguments are optional.
+        # 4) If more than one argument are required, we expect to always receive
+        #    a tuple and unpack it
+        # 5) If only a single argument is allowed, we never unpack tuples
+        # 6) If both =1 and >1 arguments are allowed, it is ambiguous whether to
+        #    unpack tuples, so this case is not allowed:  The first argument
+        #    cannot be a tuple or '?' tag if the second argument is optional.
+        
+        argspec = inspect.getargspec(self.func)
+        args = argspec.args[2:] # Skip 'self' and context data arguments.
+
+        if inspect.isgeneratorfunction(func):
+            self.func = defer.inlineCallbacks(func)
+
+        for arg in args:
+            if arg not in params:
+                params[arg] = ['?']
+
+        for p in params.keys():
+            if p not in args:
+                raise ValueError("Setting parameter {} not accepted by function".format(p))
+            if isinstance(params[p], basestring):
+                params[p] = [params[p]]
+
+        Nparams = len(args)
+        Noptional = len(argspec.defaults) if argspec.defaults else 0
+        Nrequired = Nparams - Noptional
+
+        if Nrequired > 1:
+            self.expand_cluster = "always"
+        elif Nparams > 1:
+            self.expand_cluster = "optional"
+        else: # one or fewer arguments
+            self.expand_cluster = "never"
+
+        self.allow_none = Nrequired == 0
+
+        if Nparams:
+            for tag in params[args[0]]:
+                tt = T.parseTypeTag(tag)
+                if isinstance(tt, T.LRNone) and Nrequired != 1:
+                    raise ValueError("First argument {} cannot accept '' "
+                          "unless other arguments are optional".format(args[0]))
+                if isinstance(tt, (T.LRAny, T.LRCluster)) and self.expand_cluster=="optional":
+                    raise ValueError("First argument {} cannot accept type {} "
+                          "because other arguments are optional".format(args[0], tt))
+            for arg in args[1:]:
+                for tag in params[arg]:
+                    if isinstance(T.parseTypeTag(tag), T.LRNone):
+                        raise ValueError("Argument {} cannot accept ''".format(arg))
+
+        # Build list of accepted data types.
+        # This is basically every combination of accepted types for each agrument,
+        # including omitting any number of trailing optional arguments.
+
+        accepted_types = []
+        for i in range(Nrequired, Nparams+1):
+            if i == 0:
+                accepted_types.append('_')
+            else:
+                accept_tuples = itertools.product(*[params[arg] for arg in args[:i]])
+                accepted_types.extend(''.join(x) for x in accept_tuples)
+        self.accepts = accepted_types
+
+    def __get__(self, obj, objtype):
+        """Allow direct call on settings from within the Server code
+
+        Uses the python descriptor protocol.
+        """
+        # When called on an instance, we return the setting function
+        # to allow direct calling.  When called on the class we return
+        # the Setting object so that the server code can call
+        # handleRequest
+        if obj:
+            return types.MethodType(self.func, obj, objtype)
+        else:
+            return self
+        
+    def handleRequest(self, server, c, flat_data):
+        data_type = flat_data.tag
+
+        if (self.expand_cluster == "always" or
+            (self.expand_cluster == "optional"
+             and isinstance(data_type, T.LRCluster))):
+            if self.unflatten:
+                data = flat_data.unflatten()
+            else:
+                data = flat_data.tag.partial_unflatten(flat_data.bytes,
+                                                       flat_data.endianness)
+            return self.func(server, c, *data)
+        if self.allow_none and isinstance(data_type, T.LRNone):
+            return self.func(server, c)
+
+        if self.unflatten:
+            data = flat_data.unflatten()
+            return self.func(server, c, data)
+        else:
+            return self.func(server, c, flat_data)
 
     def getRegistrationInfo(self):
         return (long(self.ID), self.name, self.description,
                 self.accepts, self.returns, self.notes)
 
-    def handleRequest(self, c, data):
-        return self.func(c, data)
-
-def setting(lr_ID, lr_name=None, returns=[], lr_num_params=2, **params):
-    """Mark a server method as a remotely-accessible setting.
-
-    The only required parameter is an integer ID.  You may
-    also provide a name to override the name of the decorated
-    function.  In addition, accepted types for each of the setting
-    parameters may be provided as named parameters with a list of
-    strings of allowed types.
-    """
-    def decorated(f):
-        args, varargs, varkw, defaults = getargspec(f)
-        args = args[lr_num_params:]
-
-        # handle generators as inlineCallbacks
-        if _isGenerator(f):
-            f = inlineCallbacks(f)
-
-        # make sure that defined params are actually accepted by the function.
-        # having extra params would not affect the running, but it is
-        # unnecessary and hence may indicate other problems with the code
-        for p in params:
-            if p not in args:
-                raise Exception("'%s' is not a valid parameter." % p)
-            # turn single string annotations into lists
-            if isinstance(params[p], str):
-                params[p] = [params[p]]
-
-        Nparams = len(args)
-        Noptional = 0 if defaults is None else len(defaults)
-        Nrequired = Nparams - Noptional
-
-        if Nparams == 0:
-            accepts_s = [''] # only accept notifier
-            accepts_t = [T.parseTypeTag(s) for s in accepts_s]
-
-            @wraps(f)
-            def handleRequest(self, c, data):
-                return f(self, c)
-
-        elif Nparams == 1:
-            accepts_s = params.get(args[0], [])
-            accepts_t = [T.parseTypeTag(s) for s in accepts_s]
-
-            if Nrequired == 0:
-                # if accepted types were specified, add '' to the list
-                # we don't add '' if the list of accepted types is empty,
-                # since this would make '' the ONLY accepted type
-                if len(accepts_t) and T.LRNone() not in accepts_t:
-                    accepts_s.append(': defaults [%s=%r]' \
-                                     % (args[0], defaults[0]))
-                    accepts_t.append(T.LRNone())
-
-                @wraps(f)
-                def handleRequest(self, c, data):
-                    if data is None:
-                        return f(self, c)
-                    return f(self, c, data)
-
-            else:
-                # nothing special to do here
-                handleRequest = f
-
-        else:
-            # sanity checks to make sure that we'll be able to
-            # correctly dispatch to the function when called
-            if Nrequired <= 1:
-                if args[0] not in params:
-                    raise Exception('Must specify types for first argument '
-                                    'when fewer than two args are required.')
-                for s in params[args[0]]:
-                    t = T.parseTypeTag(s)
-                    if isinstance(t, (T.LRAny, T.LRCluster)):
-                        raise Exception('Cannot accept cluster or ? in first '
-                                        'arg when fewer than two args are '
-                                        'required.')
-
-            # '' is not allowed on first arg when Nrequired > 1
-            types = [T.parseTypeTag(s) for s in params.get(args[0], [])]
-            if Nrequired > 1 and T.LRNone() in types:
-                raise Exception("'' not allowed when more than "
-                                "one arg is required.")
-
-            # '' is never allowed on args after the first.
-            for p in args[1:]:
-                types = [T.parseTypeTag(s) for s in params.get(p, [])]
-                if T.LRNone() in types:
-                    raise Exception("'' not allowed after first arg.")
-
-            # allowed types are as follows:
-            # one type for each parameter, with the number of
-            # parameters ranging from the total number down to
-            # and including the required number
-            # we don't include any zero-length group
-            groups = []
-            for n in range(Nparams, Nrequired-1, -1):
-                lists = [params.get(a, ['?']) for a in args[:n]]
-                if len(lists):
-                    groups += _product(lists)
-                for i, group in reversed(list(enumerate(groups))):
-                    # if there are any LRNones in the group, we remove it
-                    ts = [T.parseTypeTag(t) for t in group]
-                    if T.LRNone() in ts:
-                        groups.pop(i)
-
-            accepts_t = []
-            accepts_s = []
-            for group in groups:
-                if len(group) > 1:
-                    t = T.LRCluster(*[T.parseTypeTag(t) for t in group])
-                    s = ', '.join('%s{%s}' % (sub_t, arg)
-                                  for sub_t, arg in zip(t, args))
-                    s = '(%s)' % s
-                else:
-                    t = T.parseTypeTag(group[0])
-                    if isinstance(t, T.LRCluster):
-                        raise Exception("Can't accept cluster in first param.")
-                    s = '%s{%s}' % (group[0], args[0])
-                # add information about default values of unused params
-                if len(group) < Nparams:
-                    defstr = ', '.join('%s=%r' % (args[n], defaults[n-Nrequired])
-                                       for n in range(len(group), Nparams))
-                    s = s + ': defaults [%s]' % defstr
-                accepts_t.append(t)
-                accepts_s.append(s)
-
-            if Nrequired == 0:
-                if T.LRNone() not in accepts_t:
-                    defstr = ', '.join('%s=%r' % (a, d)
-                                       for a, d in zip(args, defaults))
-                    accepts_s.append(': defaults [%s]' % defstr)
-                    accepts_t.append(T.LRNone())
-
-                @wraps(f)
-                def handleRequest(self, c, data):
-                    if isinstance(data, tuple):
-                        return f(self, c, *data)
-                    elif data is None:
-                        return f(self, c)
-                    else:
-                        return f(self, c, data)
-            else:
-                @wraps(f)
-                def handleRequest(self, c, data):
-                    if isinstance(data, tuple):
-                        return f(self, c, *data)
-                    else:
-                        return f(self, c, data)
-
-        f.ID = lr_ID
-        f.name = lr_name or f.__name__
-        f.accepts = accepts_s
-        f.returns = [returns] if isinstance(returns, str) else returns
-        f.isSetting = True
-        f.handleRequest = handleRequest
-
-        # this is the data that will be sent to the manager to
-        # register this setting to be remotely callable
-        f.description, f.notes = util.parseSettingDoc(f.__doc__)
-        def getRegistrationInfo():
-            return (long(f.ID), f.name, f.description,
-                    f.accepts, f.returns, f.notes)
-        f.getRegistrationInfo = getRegistrationInfo
-
-        return f
-    return decorated
 
 
 class MessageHandler(object):
@@ -240,12 +212,12 @@ def messageHandler(lr_ID, lr_name=None, returns=[], lr_num_params=2, **params):
     strings of allowed types.
     """
     def decorated(f):
-        args, varargs, varkw, defaults = getargspec(f)
+        args, varargs, varkw, defaults = inspect.getargspec(f)
         args = args[lr_num_params:]
 
-        # handle generators as inlineCallbacks
-        if _isGenerator(f):
-            f = inlineCallbacks(f)
+        # handle generators as defer.inlineCallbacks
+        if inspect.isgeneratorfunction(f):
+            f = defer.inlineCallbacks(f)
 
         # make sure that defined params are actually accepted by the function.
         # having extra params would not affect the running, but it is
@@ -265,7 +237,7 @@ def messageHandler(lr_ID, lr_name=None, returns=[], lr_num_params=2, **params):
             accepts_s = [''] # only accept notifier
             accepts_t = [T.parseTypeTag(s) for s in accepts_s]
 
-            @wraps(f)
+            @functools.wraps(f)
             def handleRequest(self, c, data):
                 return f(self, c)
 
@@ -282,7 +254,7 @@ def messageHandler(lr_ID, lr_name=None, returns=[], lr_num_params=2, **params):
                                      % (args[0], defaults[0]))
                     accepts_t.append(T.LRNone())
 
-                @wraps(f)
+                @functools.wraps(f)
                 def handleRequest(self, c, data):
                     if data is None:
                         return f(self, c)
@@ -362,7 +334,7 @@ def messageHandler(lr_ID, lr_name=None, returns=[], lr_num_params=2, **params):
                     accepts_s.append(': defaults [%s]' % defstr)
                     accepts_t.append(T.LRNone())
 
-                @wraps(f)
+                @functools.wraps(f)
                 def handleRequest(self, c, data):
                     if isinstance(data, tuple):
                         return f(self, c, *data)
@@ -371,7 +343,7 @@ def messageHandler(lr_ID, lr_name=None, returns=[], lr_num_params=2, **params):
                     else:
                         return f(self, c, data)
             else:
-                @wraps(f)
+                @functools.wraps(f)
                 def handleRequest(self, c, data):
                     if isinstance(data, tuple):
                         return f(self, c, *data)

--- a/labrad/servers/test_server.py
+++ b/labrad/servers/test_server.py
@@ -92,6 +92,15 @@ class TestServer(LabradServer):
             c['delay'] = delay
         return c['delay']
 
+    @setting(42, "Delayed Echo Wrapper", data='?', returns='?')
+    def delayed_echo_wrapper(self, c, data):
+        """Echo a packet after a delay just like delayed_echo.
+
+        This tests calling a coroutine from another coroutine.
+        """
+        rv = yield self.delayed_echo(c, data)
+        returnValue(rv)
+
     @setting(40, "Speed", speed='v[m/s]', returns='v[m/s]')
     def speed(self, c, speed=None):
         """Get or set the speed."""
@@ -161,17 +170,23 @@ class TestServer(LabradServer):
         """Get a random LabRAD type tag."""
         return str(hydrant.randType())
 
-    @setting(100, "Set", key='s', value='?', returns='')
+    @setting(100, "Set", unflatten=False, key='s', value='?', returns='')
     def set(self, c, key, value):
-        c['dict'][key] = value
+        c['dict'][key.unflatten()] = value
 
     @setting(101, "Get", key='s', returns='?')
     def get(self, c, key):
+        print "getting tag: %s, value: %s" % (key, c['dict'][key])
         return c['dict'][key]
 
     @setting(102, "Keys", returns='*s')
     def keys(self, c):
         return sorted(c['dict'].keys())
+
+    @setting(103, "Set Reversed", value='?', key='s', unflatten=False)
+    def set_reversed(self, c, value, key):
+        """Same as self.set() with argument order reversed."""
+        self.set(c, key, value)
 
 def owie(dummy=None):
     raise Exception('Raised in subfunction.')

--- a/labrad/stream.py
+++ b/labrad/stream.py
@@ -42,7 +42,7 @@ def unflattenRecords(data, endianness='>'):
     s = T.Buffer(data)
     while len(s):
         ID, tag, data = T.unflatten(s, RECORD_TYPE, endianness)
-        rec = ID, T.unflatten(data, tag, endianness)
+        rec = ID, T.FlatData(data, T.parseTypeTag(tag), endianness)
         records.append(rec)
     return records
 

--- a/labrad/test/extraction_test.py
+++ b/labrad/test/extraction_test.py
@@ -30,8 +30,8 @@ mac = '01:23:45:67:89:ab'
 eth = 1
 
 packets = [(mac, mac, eth, '\x00'*44) for _ in range(9000)]
-data, t = types.flatten(packets)
+data, t, endianness = types.flatten(packets)
 
 timeIt(extract, packets)
-data, t = timeIt(types.flatten, packets)
-timeIt(types.unflatten, data, t)
+data, t, endianness = timeIt(types.flatten, packets)
+timeIt(types.unflatten, data, t, endianness)

--- a/labrad/test/test_client.py
+++ b/labrad/test/test_client.py
@@ -177,3 +177,18 @@ class ClientTests(unittest.TestCase):
         self.assertEqual(pts3.keys(), ['3'])
         self.assertEqual(pts4.keys(), ['4'])
 
+    def test_server_calls(self):
+        """Make sure that server settings can call other settings directly.
+        """
+        cxn = self.cxn()
+
+        ts = cxn.python_test_server
+
+        ts.set_reversed("bar", "foo")
+        self.assertEqual(ts.get("foo"), "bar")
+
+        ts.echo_delay(T.Value(0.1, 's'))
+        self.assertEquals(ts.delayed_echo_wrapper(1), 1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This patch extends the use of the FlatData construct and allows for server settings to decline to have its arguments unflattened.

The idea here is that servers that just accept a bunch of data and pass it on to other servers can avoid the unflattening/flattening step altogether.

Currently this is only implemented for requests.  Before merging I want to do the same for responses.  Just marking this so that @maffoo can look at it.