### PR TITLE
Add service_identity to requirements file for full TLS support.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy >= 1.9.1
 futures >= 3.0.4
 twisted >= 14.0.0
 pyOpenSSL >= 0.13
+service_identity


### PR DESCRIPTION
(Twisted doesn't specify a version, so we don't either.)

Fixes #253.