### PR TITLE
GPIB: Allow refreshing connection to GPIB device manager.

### DIFF
--- a/labrad/gpib.py
+++ b/labrad/gpib.py
@@ -289,7 +289,7 @@ class ManagedDeviceServer(LabradServer):
         """
 
         """
-        #yield self.client.refresh()
+        yield self.client.refresh()
         manager = self.client[self.deviceManager]
         #If we have a device identification function register it with the device manager
         if hasattr(self, 'deviceIdentFunc'):


### PR DESCRIPTION
For some GPIB device servers, if the GPIB device manager was started after the device server, the device server would not update the list of attached devices once the GPIB device manager was started. Uncomment out a refresh line in connectToDeviceManager to fix this, so the GPIB device manager can be started even after GPIB device servers.

Fixes martinisgroup/servers#351 (This solution was suggested by @maffoo.)