### PR TITLE
Add node config blocks to python test servers

### DIFF
--- a/labrad/servers/dying_test_server.py
+++ b/labrad/servers/dying_test_server.py
@@ -13,6 +13,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+### BEGIN NODE INFO
+[info]
+name = Dying Test Server
+version = 1.0.0
+description = Fails to start; for tests.
+
+[startup]
+cmdline = %PYTHON% %FILE%
+timeout = 20
+
+[shutdown]
+message = 987654321
+timeout = 5
+### END NODE INFO
+"""
+
 from labrad import util
 from labrad.server import LabradServer, setting, Signal
 from twisted.internet import defer, reactor

--- a/labrad/servers/test_server.py
+++ b/labrad/servers/test_server.py
@@ -13,6 +13,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+"""
+### BEGIN NODE INFO
+[info]
+name = Python Test Server
+version = 1.0.0
+description = Basic python server.
+
+[startup]
+cmdline = %PYTHON% %FILE%
+timeout = 20
+
+[shutdown]
+message = 987654321
+timeout = 5
+### END NODE INFO
+"""
+
 from labrad import types as T, util
 from labrad.server import LabradServer, setting
 from labrad.units import m, s


### PR DESCRIPTION
This makes it possible for the node to control these servers, which is useful for testing.