### PR TITLE
Node registry documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,8 @@ In addition to the basic labrad client/server support, this package also include
 This server just runs other labrad servers, allowing you to start and stop them by sending labrad requests to the node.
 By running node servers on one or more machines connected to labrad, you can remotely control which labrad servers are running on those machines.
 This can be very useful in distributed setups.
-For more information, see the [source](https://github.com/labrad/pylabrad/blob/master/labrad/node/__init__.py).
-To configure the node (e.g., define directories containing servers), it is necessary to set several registry keys;
-see the [node docstring](https://github.com/labrad/pylabrad/blob/master/labrad/node/__init__.py) for details.
+For more information, including required configuration in the LabRAD registry (to, e.g., define directories containing servers),
+see the [node docstring](https://github.com/labrad/pylabrad/blob/master/labrad/node/__init__.py).
 The node module is executable, so you should launch it with `python -m labrad.node`.
 To see documentation of the available command-line parameters run `python -m labrad.node --help`.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This server just runs other labrad servers, allowing you to start and stop them 
 By running node servers on one or more machines connected to labrad, you can remotely control which labrad servers are running on those machines.
 This can be very useful in distributed setups.
 For more information, see the [source](https://github.com/labrad/pylabrad/blob/master/labrad/node/__init__.py).
+To configure the node (e.g., define directories containing servers), it is necessary to set several registry keys;
+see the [node docstring](https://github.com/labrad/pylabrad/blob/master/labrad/node/__init__.py) for details.
 The node module is executable, so you should launch it with `python -m labrad.node`.
 To see documentation of the available command-line parameters run `python -m labrad.node --help`.
 

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -36,8 +36,6 @@ configuration keys are:
                     along with all their subdirs.
   extensions (*s): what files to look at, e.g. ['.ini', '.py', '.exe']
   autostart (*s): list of servers to be autostarted
-  javapath (s): Path for java VM, e.g. "C:\\Java\\jre1.7.0\\bin\\java.exe".
-                Needed if java or scala servers are used.
 
 Changes required on the server:
 

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -36,6 +36,8 @@ configuration keys are:
                     along with all their subdirs.
   extensions (*s): what files to look at, e.g. ['.ini', '.py', '.exe']
   autostart (*s): list of servers to be autostarted
+  javapath (s): Path for java VM, e.g. "C:\\Java\\jre1.7.0\\bin\\java.exe".
+                Needed if java or scala servers are used.
 
 Changes required on the server:
 


### PR DESCRIPTION
Add additional documentation for setting up the registry for the node. In particular:
 * In the readme, direct users to the node docstring to see registry keys which must be set up. (Added to solve #284).
 * In the node docstring, add the `javapath` key.

@maffoo or @ejeffrey?