### PR TITLE
Added read_raw and write_raw to gpib.py

### DIFF
--- a/labrad/gpib.py
+++ b/labrad/gpib.py
@@ -88,6 +88,19 @@ class GPIBDeviceWrapper(DeviceWrapper):
         returnValue(resp.write)
 
     @inlineCallbacks
+    def write_raw(self, s, timeout=None):
+        """Write a string to the device."""
+        p = self._packet()
+        if timeout is not None:
+            p.timeout(timeout)
+        p.write_raw(s)
+        if timeout is not None:
+            p.timeout(self._timeout)
+        resp = yield p.send()
+        returnValue(resp.write_raw)
+
+
+    @inlineCallbacks
     def read(self, bytes=None, timeout=None):
         """Read a string from the device."""
         p = self._packet()
@@ -98,6 +111,18 @@ class GPIBDeviceWrapper(DeviceWrapper):
             p.timeout(self._timeout)
         resp = yield p.send()
         returnValue(resp.read)
+
+    @inlineCallbacks
+    def read_raw(self, bytes=None, timeout=None):
+        """Read a string from the device."""
+        p = self._packet()
+        if timeout is not None:
+            p.timeout(timeout)
+        p.read_raw(bytes)
+        if timeout is not None:
+            p.timeout(self._timeout)
+        resp = yield p.send()
+        returnValue(resp.read_raw)
 
     def initialize(self):
         """Called when we first connect to the device.


### PR DESCRIPTION
I was having difficulty sending binary strings to GPIB devices as there was no write_raw command.

This just adds that functionality,  I thought others might benefit as well.

I added read_raw as well for the hell of it.