### PR TITLE
When flattening numpy arrays, use element type from type tag.

### DIFF
--- a/labrad/test/test_types.py
+++ b/labrad/test/test_types.py
@@ -362,6 +362,15 @@ class LabradTypesTests(unittest.TestCase):
         y = T.unflatten(*flat)
         self.assertTrue(np.all(x == y))
 
+    def testFlattenArrayToClusterList(self):
+        """Fail if trying to flatten a numpy array to type with incorrect shape.
+
+        See https://github.com/labrad/pylabrad/issues/290.
+        """
+        arr = np.arange(5, dtype='float64')
+        with self.assertRaises(T.FlatteningError):
+            T.flatten(arr, types=['*(v, v)'])
+
     def testCanFlattenFlatData(self):
         x = ('this is a test', -42, [False, True])
         flat = T.flatten(x)

--- a/labrad/types.py
+++ b/labrad/types.py
@@ -308,7 +308,8 @@ class FlatData(collections.namedtuple('FlatDataBase', ['bytes', 'tag', 'endianne
     __slots__ = ()
     def unflatten(self, endianness='>'):
         return unflatten(self.bytes, self.tag, self.endianness)
-    
+
+
 def flatten(obj, types=None, endianness='>'):
     """Flatten python data into labrad data.
 
@@ -1311,7 +1312,8 @@ class LRList(LRType):
                     raise Exception("Narrowing typecast loses information while flattening numpy array: dtype={0}, wanted_dtype={1}".format(a.dtype, wanted_dtype))
                 a = a_cast
         else:
-            elems = (flatten(i, endianness=endianness).bytes for i in a.flat)
+            elems = (self.elem.flatten(i, endianness=endianness).bytes
+                     for i in a.flat)
             return dims + ''.join(elems), self
         return dims + a.tostring(), self
 


### PR DESCRIPTION
Previously, this fallback path flattened elements based on the type of
the data elements, rather than the element type of the LRList type
object. This could result in invalid flattened data.

Fixes #290.

@zchen088 