### PR TITLE
Support using oauth access token to log in to labrad.

### DIFF
--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -387,7 +387,7 @@ class LabradProtocol(protocol.Protocol):
 
             if oauth_methods & allowed:
                 if 'oauth_access_token' in allowed:
-                    # Prefer using access token if manager support it.
+                    # Prefer using access token if manager supports it.
                     method = 'oauth_access_token'
                 else:
                     method = 'oauth_token'


### PR DESCRIPTION
Manager support is in scalabrad (https://github.com/labrad/scalabrad/pull/75) but this still allows logging to older managers that just support id token login.