### PR TITLE
Add ThreadedServer class that handles requests in a thread pool

### DIFF
--- a/labrad/concurrent.py
+++ b/labrad/concurrent.py
@@ -103,14 +103,14 @@ def future_to_deferred(future):
     deferred = defer.Deferred()
     def handle_result(future):
         if future.cancelled():
-            deferred.errback(futures.CancelledError())
+            reactor.callFromThread(deferred.errback, futures.CancelledError())
             return
         error = future.exception()
         if error is not None:
-            deferred.errback(error)
+            reactor.callFromThread(deferred.errback, error)
             return
         result = future.result()
-        deferred.callback(result)
+        reactor.callFromThread(deferred.callback, result)
     future.add_done_callback(handle_result)
     return deferred
 

--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -37,6 +37,7 @@ class LabradProtocol(protocol.Protocol):
 
     def __init__(self):
         self.disconnected = False
+        self._next_context = 1
         self._nextRequest = 1
         self.pool = set()
         self.requests = {}
@@ -64,6 +65,12 @@ class LabradProtocol(protocol.Protocol):
         """
         self.host = host
         self.port = port
+
+    def context(self):
+        """Create a new communication context for this connection."""
+        context = (0, self._next_context)
+        self._next_context += 1
+        return context
 
     # network events
     def connectionMade(self):

--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -472,7 +472,9 @@ class LabradProtocol(protocol.Protocol):
 
     @inlineCallbacks
     def _doLogin(self, *ident):
-        # send identification
+        # Store name, which is always the first identification param.
+        self.name = ident[0]
+        # Send identification.
         self.ID = yield self._sendManagerRequest(0, (1L,) + ident)
 
 

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -206,7 +206,7 @@ class LabradServer(object):
 
         self.__protocol = None
         self.__async_client = None
-        self.__sync_client = threading.local()
+        self.__thread_data = threading.local()
 
     def _dispatch(self, func, *args, **kw):
         return func(*args, **kw)
@@ -373,10 +373,11 @@ class LabradServer(object):
             # We're in the reactor thread, so can return shared async client.
             return self.__async_client
         else:
-            if not hasattr(self.__sync_client, 'cxn'):
-                backend = labrad.backend.TwistedConnection(async_cxn=self.__protocol)
-                self.__sync_client.cxn = Client(backend)
-            return self.__sync_client.cxn
+            data = self.__thread_data
+            if not hasattr(data, 'sync_client'):
+                backend = labrad.backend.TwistedConnection(self.__protocol)
+                data.sync_client = Client(backend)
+            return data.sync_client
 
     # Network events
     # these methods are called by network events from twisted

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -583,9 +583,29 @@ class LabradServer(object):
 class ThreadedServer(LabradServer):
     """A LabRAD server that dispatches requests to a thread pool."""
 
+    def __init__(self, pool=None):
+        """Create a new threaded server.
+
+        Requests and lifecycle methods like initServer will be executed on a
+        thread pool instead of in the twisted reactor thread. In addition,
+        accessing self.client from a thread other than the reactor thread will
+        return a synchronous labrad.client.Client object.
+
+        Args:
+            pool (None | concurrent.futures.ThreadPoolExecutor):
+                Thread pool instance to use for server lifecycle methods and
+                request handling. If None, use the default twisted threadpool,
+                which maxes out at 10 threads.
+        """
+        super(ThreadedServer, self).__init__()
+        self.__pool = pool
+
     @inlineCallbacks
     def _dispatch(self, func, *args, **kw):
-        result = yield threads.deferToThread(func, *args, **kw)
+        if self.__pool is None:
+            result = yield threads.deferToThread(func, *args, **kw)
+        else:
+            result = self.__pool.submit(func, *args, **kw)
         if isinstance(result, futures.Future):
             result = yield labrad.concurrent.future_to_deferred(result)
         returnValue(result)

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -22,14 +22,17 @@ servers with labrad.
 
 from datetime import datetime
 from operator import attrgetter
+import threading
 import traceback
 
-from twisted.internet import defer, reactor
+from twisted.internet import defer, reactor, threads
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.error import ConnectionDone, ConnectionLost
-from twisted.python import failure, log
+from twisted.python import failure, log, threadable
 
 from labrad import constants as C, types as T, util
+import labrad.backend
+from labrad.client import Client
 from labrad.decorators import setting
 from labrad.wrappers import ClientAsync
 
@@ -197,6 +200,13 @@ class LabradServer(object):
         self.signals = []
         self.contexts = {}
 
+        self.__protocol = None
+        self.__async_client = None
+        self.__sync_client = threading.local()
+
+    def _dispatch(self, func, *args, **kw):
+        return func(*args, **kw)
+
     # request handling
     @inlineCallbacks
     def request_handler(self, source, context, flat_records):
@@ -211,8 +221,8 @@ class LabradServer(object):
         if c is None:
             c = self.contexts[context] = Context()
             yield c.acquire() # make sure we're the first in line
-            c.data = yield self.newContext(context)
-            yield self.initContext(c.data)
+            c.data = yield self._dispatch(self.newContext, context)
+            yield self._dispatch(self.initContext, c.data)
         else:
             yield c.acquire() # wait for previous requests in this context to finish
 
@@ -224,12 +234,12 @@ class LabradServer(object):
             yield util.wakeupCall(0.0)
         response = []
         try:
-            yield self.startRequest(c.data, source)
+            yield self._dispatch(self.startRequest, c.data, source)
             for ID, flat_data in flat_records:
                 c.check() # make sure this context hasn't expired
                 try:
                     setting = self.settings[ID]
-                    result = yield setting.handleRequest(self, c.data, flat_data)
+                    result = yield self._dispatch(setting.handleRequest, self, c.data, flat_data)
                     response.append((ID, result, setting.returns))
                 except Exception, e:
                     response.append((ID, self._getTraceback(e)))
@@ -341,8 +351,9 @@ class LabradServer(object):
             self.ID = protocol.ID
             protocol.request_handler = self.request_handler
             protocol.onDisconnect().addBoth(self._connection_lost)
-            self.client = ClientAsync(protocol)
-            yield self.client._init()
+            self.__protocol = protocol
+            self.__async_client = ClientAsync(protocol)
+            yield self.__async_client._init()
             yield self._initServer()
             self.started = True
             self.onStartup.callback(self)
@@ -351,6 +362,17 @@ class LabradServer(object):
             traceback.print_exc()
             self.disconnect(e)
             raise
+
+    @property
+    def client(self):
+        if threadable.isInIOThread():
+            # We're in the reactor thread, so can return shared async client.
+            return self.__async_client
+        else:
+            if not hasattr(self.__sync_client, 'cxn'):
+                backend = labrad.backend.TwistedConnection(async_cxn=self.__protocol)
+                self.__sync_client.cxn = Client(backend)
+            return self.__sync_client.cxn
 
     # Network events
     # these methods are called by network events from twisted
@@ -375,7 +397,7 @@ class LabradServer(object):
         yield p.send()
 
         # do server-specific initialization
-        yield self.initServer()
+        yield self._dispatch(self.initServer)
         # make sure we shut down gracefully when reactor quits or a remote message is fired
         self._shutdownID = reactor.addSystemEventTrigger('before', 'shutdown', self._stopServer)
         self._cxn.addListener(self._stopServer, ID=987654321)
@@ -399,7 +421,7 @@ class LabradServer(object):
     def _stopServer(self, *ignored):
         self.stopping = True
         try:
-            yield self.stopServer()
+            yield self._dispatch(self.stopServer)
         except Exception, e:
             self._error = failure.Failure(e)
         finally:
@@ -460,12 +482,12 @@ class LabradServer(object):
     def _serverConnected(self, c, data):
         """Handle connection messages from the manager."""
         ID, name = data
-        self.serverConnected(ID, name)
+        self._dispatch(self.serverConnected, ID, name)
 
     def _serverDisconnected(self, c, data):
         """Handle disconnection messages from the manager."""
         ID, name = data
-        self.serverDisconnected(ID, name)
+        self._dispatch(self.serverDisconnected, ID, name)
 
     # these methods should be overridden
     def serverConnected(self, ID, name):
@@ -509,7 +531,7 @@ class LabradServer(object):
             c = self.contexts[context]
             del self.contexts[context]
             c.expire()
-            self.expireContext(c.data)
+            self._dispatch(self.expireContext, c.data)
 
     # these methods may be overridden
     def newContext(self, ID):
@@ -551,4 +573,11 @@ class LabradServer(object):
 
     def log(self, *messages):
         self.onLog((datetime.now(), messages))
+
+
+class ThreadedServer(LabradServer):
+    """A LabRAD server that dispatches requests to a thread pool."""
+
+    def _dispatch(self, func, *args, **kw):
+        return threads.deferToThread(func, *args, **kw)
 

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -613,7 +613,7 @@ class ThreadedServer(LabradServer):
             result = yield threads.deferToThread(func, *args, **kw)
         else:
             result = self.__pool.submit(func, *args, **kw)
-        if isinstance(result, futures.Future):
+        while isinstance(result, futures.Future):
             result = yield labrad.concurrent.future_to_deferred(result)
         returnValue(result)
 

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -35,7 +35,7 @@ from twisted.python import failure, log, threadable
 
 from labrad import constants as C, types as T, util
 import labrad.backend
-from labrad.client import Client
+import labrad.client
 import labrad.concurrent
 from labrad.decorators import setting
 from labrad.wrappers import ClientAsync
@@ -376,7 +376,7 @@ class LabradServer(object):
             data = self.__thread_data
             if not hasattr(data, 'sync_client'):
                 backend = labrad.backend.TwistedConnection(self.__protocol)
-                data.sync_client = Client(backend)
+                data.sync_client = labrad.client.Client(backend)
             return data.sync_client
 
     # Network events

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -617,3 +617,10 @@ class ThreadedServer(LabradServer):
             result = yield labrad.concurrent.future_to_deferred(result)
         returnValue(result)
 
+
+class SingleThreadedServer(ThreadedServer):
+    """A LabRAD server that handles requests in a single thread."""
+    def __init__(self):
+        pool = futures.ThreadPoolExecutor(max_workers=1)
+        super(SingleThreadedServer, self).__init__(pool)
+

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -369,6 +369,13 @@ class LabradServer(object):
 
     @property
     def client(self):
+        """Get a labrad client for this server's labrad connection.
+
+        To accomodate asynchronous and synchronous (threaded) server
+        implementations, this returns a single shared AsyncClient instance if
+        called from the twisted reactor thread, or a thread-local Client
+        instance for synchronous use if called from any other thread.
+        """
         if threadable.isInIOThread():
             # We're in the reactor thread, so can return shared async client.
             return self.__async_client

--- a/labrad/servers/threaded_test_server.py
+++ b/labrad/servers/threaded_test_server.py
@@ -1,0 +1,156 @@
+"""
+### BEGIN NODE INFO
+[info]
+name = Python Threaded Test Server
+version = 1.0.0
+description = Basic python server.
+
+[startup]
+cmdline = %PYTHON% %FILE%
+timeout = 20
+
+[shutdown]
+message = 987654321
+timeout = 5
+### END NODE INFO
+"""
+
+import time
+
+from labrad import types as T, util
+from labrad.server import ThreadedServer, setting
+from labrad.units import m, s
+from labrad.util import hydrant
+
+
+class TestServer(ThreadedServer):
+    """Server to test labrad from python.
+
+    This server provides a number of settings that
+    are useful for testing labrad code, network profiling,
+    and testing the python labrad library.
+    """
+    name = 'Python Threaded Test Server'
+    testMode = True
+    shutdownMessage = 987654321
+
+    def initServer(self):
+        time.sleep(0.5)
+
+    def stopServer(self):
+        print 'before sleep'
+        time.sleep(0.5)
+        print 'after sleep'
+
+    def serverConnected(self, ID, name):
+        print 'server connected:', ID, name
+
+    def serverDisconnected(self, ID, name):
+        print 'server disconnected:', ID, name
+
+    def initContext(self, c):
+        c['delay'] = 1*s
+        c['dict'] = {}
+
+    @setting(2, "Delayed Echo", data='?')
+    def delayed_echo(self, c, data):
+        """Echo a packet after a specified delay."""
+        time.sleep(c['delay'][s])
+        return data
+
+    @setting(3, "Future Echo", data='?')
+    def future_echo(self, c, data):
+        """Echo a packet after a specified delay."""
+        f = self.client.manager.echo.future(data)
+        time.sleep(c['delay'][s])
+        return f
+
+    @setting(4, "Echo Delay", delay='v[s]', returns='v[s]')
+    def echo_delay(self, c, delay=None):
+        """Get or set the echo delay."""
+        self.log('Echo delay: %s' % delay)
+        if delay is not None:
+            c['delay'] = delay
+        return c['delay']
+
+    @setting(42, "Delayed Echo Wrapper", data='?', returns='?')
+    def delayed_echo_wrapper(self, c, data):
+        """Echo a packet after a delay just like delayed_echo.
+
+        This tests calling a setting from another setting.
+        """
+        rv = self.delayed_echo(c, data)
+        return rv
+
+    @setting(40, "Speed", speed='v[m/s]', returns='v[m/s]')
+    def speed(self, c, speed=None):
+        """Get or set the speed."""
+        self.log('Speed: %s' % speed)
+        if speed is not None:
+            c['speed'] = speed
+        return c['speed']
+
+    @setting(41, "Verbose Echo", data='?')
+    def verbose_echo(self, c, data):
+        print type(data)
+        print repr(data)
+        return data
+
+    @setting(5, "Exc in Handler", data='?')
+    def exc_in_handler(self, c, data):
+        """Raises an exception directly in the handler."""
+        self.log('Exception in handler.')
+        raise Exception('Raised in handler.')
+
+    @setting(9, "Exc after delay", data='?')
+    def exc_in_inlinecallback(self, c, data):
+        """Raises an exception after a delay."""
+        self.log('Exception after delay.')
+        time.sleep(c['delay'][s])
+        raise Exception('Raised after delay.')
+
+    @setting(10, "Bad Return Type", data='?', returns='s')
+    def bad_return_type(self, c, data):
+        """Returns a value that does not match the declared return type."""
+        return 5
+
+    @setting(11, "Get Random Data", tag='s')
+    def get_random_data(self, c, tag=None):
+        """Get a random bit of data conforming to the specified type tag."""
+        if tag is None:
+            t = hydrant.randType()
+        else:
+            t = T.parseTypeTag(tag)
+        return hydrant.randValue(t)
+
+    @setting(12, "Get Random Tag")
+    def get_random_tag(self, c):
+        """Get a random LabRAD type tag."""
+        return str(hydrant.randType())
+
+    @setting(100, "Set", unflatten=False, key='s', value='?', returns='')
+    def set(self, c, key, value):
+        c['dict'][key.unflatten()] = value
+
+    @setting(101, "Get", key='s', returns='?')
+    def get(self, c, key):
+        print "getting tag: %s, value: %s" % (key, c['dict'][key])
+        return c['dict'][key]
+
+    @setting(102, "Keys", returns='*s')
+    def keys(self, c):
+        return sorted(c['dict'].keys())
+
+    @setting(103, "Set Reversed", value='?', key='s', unflatten=False)
+    def set_reversed(self, c, value, key):
+        """Same as self.set() with argument order reversed."""
+        self.set(c, key, value)
+
+    @setting(1000, path=['', 's'], file=['s'])
+    def first_arg_can_have_default_value(self, c, path=None, file=None):
+        """Exercise setting decorator fix from issue #242."""
+        pass
+
+
+if __name__ == '__main__':
+    util.runServer(TestServer())

--- a/labrad/servers/threaded_test_server.py
+++ b/labrad/servers/threaded_test_server.py
@@ -73,6 +73,17 @@ class TestServer(ThreadedServer):
             c['delay'] = delay
         return c['delay']
 
+    @setting(2000, "Registry Dir", path='*s', returns='(*s, *s)')
+    def registry_dir(self, c, path=['']):
+        """Get Registry listing for the specified path."""
+        p = self.client.registry.packet()
+        p.cd([''])
+        p.cd(path)
+        p.dir()
+        result = p.send()
+        dirs, keys = result['dir']
+        return dirs, keys
+
     @setting(42, "Delayed Echo Wrapper", data='?', returns='?')
     def delayed_echo_wrapper(self, c, data):
         """Echo a packet after a delay just like delayed_echo.

--- a/labrad/test/test_concurrent.py
+++ b/labrad/test/test_concurrent.py
@@ -1,14 +1,17 @@
 from __future__ import absolute_import
 
 from concurrent.futures import Future
+from twisted.internet import defer, reactor
+from twisted.python import threadable
 import pytest
 
-from labrad.concurrent import map_future
+import labrad.concurrent as concurrent
+import labrad.thread as thread
 
 
 def test_map_future():
     f = Future()
-    mf = map_future(f, lambda x: x + 1)
+    mf = concurrent.map_future(f, lambda x: x + 1)
     f.set_result(1)
     assert mf.result() == 2
 
@@ -16,8 +19,135 @@ def test_map_future():
 def test_map_future_on_already_completed_future():
     f = Future()
     f.set_result(1)
-    mf = map_future(f, lambda x: x + 1)
+    mf = concurrent.map_future(f, lambda x: x + 1)
     assert mf.result() == 2
+
+
+class TestCallFuture(object):
+    """Test call_future function, which wraps twisted code in a Future."""
+
+    @classmethod
+    def setup_class(cls):
+        # make sure twisted reactor is running
+        thread.startReactor()
+
+    def test_synchronous_func(self):
+        def func():
+            return threadable.isInIOThread()
+
+        f = concurrent.call_future(func)
+        assert f.result(timeout=0.1)
+
+    def test_synchronous_error(self):
+        def func():
+            raise ValueError()
+
+        f = concurrent.call_future(func)
+        with pytest.raises(ValueError):
+            f.result(timeout=0.1)
+
+    def test_asynchronous_func(self):
+        @defer.inlineCallbacks
+        def func():
+            d = defer.Deferred()
+            reactor.callLater(0, d.callback, 'woot')
+            result = yield d
+            defer.returnValue(result)
+
+        f = concurrent.call_future(func)
+        assert f.result(timeout=0.1) == 'woot'
+
+    def test_asynchronous_error(self):
+        @defer.inlineCallbacks
+        def func():
+            d = defer.Deferred()
+            reactor.callLater(0, d.callback, 'woot')
+            result = yield d
+            raise ValueError()
+
+        f = concurrent.call_future(func)
+        with pytest.raises(ValueError):
+            f.result(timeout=0.1)
+
+
+class TestFutureToDeferred(object):
+    """Test future_to_deferred which wraps a Future in a twisted Deferred."""
+
+    @classmethod
+    def setup_class(cls):
+        # make sure twisted reactor is running
+        thread.startReactor()
+
+    def test_result_already_set(self):
+        @defer.inlineCallbacks
+        def func(f):
+            result = yield concurrent.future_to_deferred(f)
+            defer.returnValue(result)
+
+        f1 = Future()
+        f1.set_result(1)
+        f2 = concurrent.call_future(func, f1)
+        assert f2.result(timeout=0.1) == 1
+
+    def test_set_result_outside_reactor(self):
+        @defer.inlineCallbacks
+        def func(f):
+            result = yield concurrent.future_to_deferred(f)
+            defer.returnValue(result)
+
+        f1 = Future()
+        f2 = concurrent.call_future(func, f1)
+        f1.set_result(1)
+        assert f2.result(timeout=0.1) == 1
+
+    def test_set_result_inside_reactor(self):
+        @defer.inlineCallbacks
+        def func(f):
+            d = concurrent.future_to_deferred(f)
+            f.set_result(1)
+            result = yield d
+            defer.returnValue(result)
+
+        f = Future()
+        future = concurrent.call_future(func, f)
+        assert future.result() == 1
+
+    def test_exception_already_set(self):
+        @defer.inlineCallbacks
+        def func(f):
+            result = yield concurrent.future_to_deferred(f)
+            defer.returnValue(result)
+
+        f1 = Future()
+        f1.set_exception(ValueError())
+        f2 = concurrent.call_future(func, f1)
+        with pytest.raises(ValueError):
+            f2.result(timeout=0.1)
+
+    def test_set_exception_outside_reactor(self):
+        @defer.inlineCallbacks
+        def func(f):
+            result = yield concurrent.future_to_deferred(f)
+            defer.returnValue(result)
+
+        f1 = Future()
+        f2 = concurrent.call_future(func, f1)
+        f1.set_exception(ValueError())
+        with pytest.raises(ValueError):
+            f2.result(timeout=0.1)
+
+    def test_set_result_inside_reactor(self):
+        @defer.inlineCallbacks
+        def func(f):
+            d = concurrent.future_to_deferred(f)
+            f.set_exception(ValueError())
+            result = yield d
+            defer.returnValue(result)
+
+        f = Future()
+        future = concurrent.call_future(func, f)
+        with pytest.raises(ValueError):
+            future.result()
 
 
 if __name__ == '__main__':

--- a/labrad/wrappers.py
+++ b/labrad/wrappers.py
@@ -428,7 +428,6 @@ class ClientAsync(object):
         self._cache = {}
         self._cxn = prot
         self._mgr = manager.AsyncManager(self._cxn)
-        self._next_context = 1
         self._refreshLock = defer.DeferredLock()
 
     _staticAttrs = ['servers', 'refresh', 'context']
@@ -548,9 +547,7 @@ class ClientAsync(object):
 
     def context(self):
         """Create a new communication context for this connection."""
-        context = (0, self._next_context)
-        self._next_context += 1
-        return context
+        return self._cxn.context()
 
     def __getitem__(self, key):
         return self.servers[key]


### PR DESCRIPTION
Most of the work here is in refactoring the synchronous backend connection so that it nicely wraps an existing async `LabradProtocol` object, rather than creating its own. The `labrad.backend.connect` function is modified to first connect asynchronously and then wrap the resulting protocol object in a `TwistedConnection`. In the threaded server we can wrap the server's protocol instance and create synchronous clients from that to give out to different threads. We push the context counter down into the protocol object itself so that synchronous and asynchronous wrappers for a given protocol instance will all be guaranteed to get unique contexts.

In `LabradServer` we modify the code that calls user-overridden methods and setting handlers to use the `_dispatch` function, which by default just calls them in the twisted reactor thread, as is currently the case. In the new `ThreadedServer` class, `_dispatch` is overridden to instead call these functions in a threadpool. In addition, the `client` property on servers is modified to return an async client or sync client, depending on which thread it is called from. This means that both threaded and non-threaded servers can get access to an appropriate labrad connection via `self.client`.