### PR TITLE
Support spawning async connections.

### DIFF
--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -429,8 +429,8 @@ class Node(object):
         while True:
             print 'Connecting to {}:{}...'.format(self.host, self.port)
             try:
-                p = yield protocol.connect(self.host, self.port, self.tls_mode)
-                yield p.authenticate(self.username, self.password)
+                p = yield protocol.connect(self.host, self.port, self.tls_mode,
+                                           self.username, self.password)
                 node = NodeServer(self.nodename, self.host, self.port,
                                   p.credential)
                 yield node.startup(p)

--- a/labrad/servers/dying_test_server.py
+++ b/labrad/servers/dying_test_server.py
@@ -38,7 +38,7 @@ from twisted.python import log
 
 from datetime import datetime
 
-class TestServer(LabradServer):
+class DyingTestServer(LabradServer):
     """Server to test labrad from python.
 
     This server provides a number of settings that
@@ -134,8 +134,6 @@ class TestServer(LabradServer):
 def owie(dummy=None):
     raise Exception('Raised in subfunction.')
 
-__server__ = TestServer()
-
 if __name__ == '__main__':
     from labrad import util
-    util.runServer(__server__)
+    util.runServer(DyingTestServer())

--- a/labrad/servers/test_server.py
+++ b/labrad/servers/test_server.py
@@ -39,7 +39,7 @@ from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
 
 
-class TestServer(LabradServer):
+class PythonTestServer(LabradServer):
     """Server to test labrad from python.
 
     This server provides a number of settings that
@@ -213,7 +213,5 @@ class TestServer(LabradServer):
 def owie(dummy=None):
     raise Exception('Raised in subfunction.')
 
-__server__ = TestServer()
-
 if __name__ == '__main__':
-    util.runServer(__server__)
+    util.runServer(PythonTestServer())

--- a/labrad/servers/threaded_test_server.py
+++ b/labrad/servers/threaded_test_server.py
@@ -23,7 +23,7 @@ from labrad.units import m, s
 from labrad.util import hydrant
 
 
-class TestServer(ThreadedServer):
+class ThreadedTestServer(ThreadedServer):
     """Server to test labrad from python.
 
     This server provides a number of settings that
@@ -164,4 +164,4 @@ class TestServer(ThreadedServer):
 
 
 if __name__ == '__main__':
-    util.runServer(TestServer())
+    util.runServer(ThreadedTestServer())

--- a/labrad/test/test_client.py
+++ b/labrad/test/test_client.py
@@ -2,7 +2,7 @@ import unittest
 
 import labrad
 from labrad import types as T
-from labrad.servers.test_server import TestServer
+from labrad.servers.test_server import PythonTestServer
 from labrad.util import syncRunServer
 
 TEST_STR = 'this is a test, this is only a test'
@@ -15,7 +15,7 @@ class ClientTests(unittest.TestCase):
         context manager as part of a test fixture.  This method then calls
         the usual test fixture setUp and tearDown within this context.
         """
-        with syncRunServer(TestServer()):
+        with syncRunServer(PythonTestServer()):
             super(ClientTests, self).run(result)
 
     def setUp(self):
@@ -170,6 +170,21 @@ class ClientTests(unittest.TestCase):
 
         ts.echo_delay(T.Value(0.1, 's'))
         self.assertEquals(ts.delayed_echo_wrapper(1), 1)
+
+    def test_spawn(self):
+        cxn1 = self.cxn()
+
+        # Can spawn from active client.
+        with cxn1.spawn() as cxn2:
+            self.assertTrue(cxn2.connected)
+            cxn2.manager.servers()
+
+        # Can spawn from client after disconnect
+        self.assertFalse(cxn2.connected)
+        with cxn2.spawn() as cxn3:
+            self.assertTrue(cxn3.connected)
+            cxn3.manager.servers()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/labrad/util/__init__.py
+++ b/labrad/util/__init__.py
@@ -395,8 +395,8 @@ def runServer(srv, run_reactor=True, stop_reactor=True):
         port = int(config['port'])
         tls_mode = config['tls']
         try:
-            p = yield protocol.connect(host, port, tls_mode)
-            yield p.authenticate(config['username'], config['password'])
+            p = yield protocol.connect(host, port, tls_mode, config['username'],
+                                       config['password'])
             yield srv.startup(p)
             yield srv.onShutdown()
             log.msg('Disconnected cleanly.')
@@ -430,8 +430,7 @@ def syncRunServer(srv, host=C.MANAGER_HOST, port=None, username=None,
 
     @inlineCallbacks
     def start_server():
-        p = yield protocol.connect(host, port, tls_mode)
-        yield p.authenticate(username, password)
+        p = yield protocol.connect(host, port, tls_mode, username, password)
         yield srv.startup(p)
 
     @inlineCallbacks

--- a/labrad/wrappers.py
+++ b/labrad/wrappers.py
@@ -21,7 +21,7 @@ from types import MethodType
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from labrad import constants as C, manager, protocol, support, types as T
+from labrad import constants as C, manager, protocol, types as T
 from labrad.support import (indent, mangle, extractKey, MultiDict, PacketRecord,
                             PacketResponse, hexdump)
 

--- a/labrad/wrappers.py
+++ b/labrad/wrappers.py
@@ -21,7 +21,7 @@ from types import MethodType
 from twisted.internet import defer
 from twisted.internet.defer import inlineCallbacks, returnValue
 
-from labrad import constants as C, manager, protocol, types as T
+from labrad import constants as C, manager, protocol, support, types as T
 from labrad.support import (indent, mangle, extractKey, MultiDict, PacketRecord,
                             PacketResponse, hexdump)
 
@@ -387,27 +387,28 @@ class AsyncServerWrapper(object):
         """Send packet to this server."""
         return self._cxn._send(self.ID, *args, **kw)
 
+
 @inlineCallbacks
 def getConnection(host=C.MANAGER_HOST, port=None, name="Python Client",
                   password=None, tls_mode=C.MANAGER_TLS, username=None,
                   headless=False):
     """Connect to LabRAD and return a deferred that fires the protocol object."""
-    p = yield protocol.connect(host, port, tls_mode)
-    yield p.authenticate(username, password, headless)
+    p = yield protocol.connect(host, port, tls_mode, username, password,
+                               headless)
     yield p.loginClient(name)
     returnValue(p)
 
+
 @inlineCallbacks
-def connectAsync(host=C.MANAGER_HOST, port=None, name="Python Client",
+def connectAsync(host=C.MANAGER_HOST, port=None, name=None,
                  password=None, tls_mode=C.MANAGER_TLS, username=None,
                  headless=False):
     """Connect to LabRAD and return a deferred that fires the client object."""
     p = yield getConnection(host, port, name, password, tls_mode=tls_mode,
                             username=username, headless=headless)
-    cxn = ClientAsync(p)
-    yield cxn._init()
-    cxn.onDisconnect = p.onDisconnect
+    cxn = yield ClientAsync.create(p)
     returnValue(cxn)
+
 
 def runAsync(func, *args, **kw):
     from twisted.internet import reactor
@@ -420,8 +421,16 @@ def runAsync(func, *args, **kw):
     reactor.callWhenRunning(runIt)
     reactor.run()
 
+
 class ClientAsync(object):
     """Adapt a LabRAD request protocol object to an asynchronous client."""
+
+    @staticmethod
+    @inlineCallbacks
+    def create(protocol):
+        cxn = ClientAsync(protocol)
+        yield cxn._init()
+        returnValue(cxn)
 
     def __init__(self, prot):
         self.servers = MultiDict()
@@ -469,6 +478,10 @@ class ClientAsync(object):
         except Exception, e:
             print 'Error removing server %d, "%s":' % (ID, name)
             print str(e)
+
+    @property
+    def onDisconnect(self):
+        return self._cxn.onDisconnect
 
     def refresh(self):
         return self._refreshLock.run(self._refresh)
@@ -548,6 +561,12 @@ class ClientAsync(object):
     def context(self):
         """Create a new communication context for this connection."""
         return self._cxn.context()
+
+    @inlineCallbacks
+    def spawn(self):
+        p = yield self._cxn.spawn()
+        cxn = yield ClientAsync.create(p)
+        returnValue(cxn)
 
     def __getitem__(self, key):
         return self.servers[key]


### PR DESCRIPTION
By pushing the spawn logic down into the async protocol instance, it
becomes possible to spawn async clients and sync clients wrapped around
async connections without using `labrad.connect`, as in ThreadedServer.

Fixes #301 