### PR TITLE
Update gitignore with standard generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,111 @@
+# gedit backup files
+*~
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
 labrad/version.py
 pylabrad.egg-info/
 *.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Text editor backups, etc. #
+############################
+*.swp
+*.swo
+*.swn
+
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
 *.pyc
+*.pyo
+ 
+# Packages #
+############
+# it's better to unpack these files and commit the raw source
+# git has its own built in compression methods
+*.7z
+*.dmg
+*.gz
+*.iso
+*.jar
+*.rar
+*.tar
+*.zip
+ 
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+ 
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE stuff #
+#############
+.cache-*
+.classpath
+.idea/
+.project
+.pydevproject
+.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,5 @@
-# gedit backup files
+# gedit & vim backup files
 *~
-
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
-
-# C extensions
-*.so
 
 # Distribution / packaging
 .Python
@@ -55,25 +48,24 @@ docs/_build/
 # PyBuilder
 target/
 
-# Text editor backups, etc. #
-############################
+# Text editor backups, etc.
 *.swp
 *.swo
 *.swn
 
-# Compiled source #
-###################
+# Compiled source
 *.com
 *.class
 *.dll
 *.exe
 *.o
 *.so
+__pycache__/
 *.pyc
 *.pyo
  
-# Packages #
-############
+# Packages 
+# --------
 # it's better to unpack these files and commit the raw source
 # git has its own built in compression methods
 *.7z
@@ -85,14 +77,12 @@ target/
 *.tar
 *.zip
  
-# Logs and databases #
-######################
+# Logs and databases
 *.log
 *.sql
 *.sqlite
  
-# OS generated files #
-######################
+# OS generated files
 .DS_Store
 .DS_Store?
 ._*
@@ -102,7 +92,6 @@ ehthumbs.db
 Thumbs.db
 
 # IDE stuff #
-#############
 .cache-*
 .classpath
 .idea/


### PR DESCRIPTION
Use a common, standard gitignore to make it easier to manage staged files regardless of editor or intermediate/generated files.