### PR TITLE
Update wheel configuration for py2 and py3

### DIFF
--- a/dist_build.sh
+++ b/dist_build.sh
@@ -4,5 +4,4 @@
 # other builds, so that we don't accumulate lots of packages locally.
 
 rm -r dist/
-python setup.py sdist --format=zip,gztar \
-                bdist_wheel
+python setup.py sdist bdist_wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[sdist]
+formats=zip,gztar


### PR DESCRIPTION
This will let us release a new version whose wheel works with python 2 and 3, now that we are compatible.