### PR TITLE
Use next(it) instead of it.next() in ValueArray constructor

### DIFF
--- a/labrad/test/test_units.py
+++ b/labrad/test/test_units.py
@@ -71,6 +71,11 @@ class LabradUnitsTests(unittest.TestCase):
         self.assertTrue(np.isfinite(ValueArray([1, 2], 'GHz')).all())
         self.assertTrue((np.isfinite(ValueArray([1, float('nan')], 'GHz')) == np.array([True, False])).all())
 
+    def testValueArrayConstruction(self):
+        v1 = ValueArray([Value(1, 'MHz'), Value(1, 'GHz')])
+        v2 = ValueArray([1, 1000], 'MHz')
+        self.assertTrue((v1 == v2).all())
+
     def testNegativePowers(self):
         self.assertEqual(str(units.Unit('1/s')), 's^-1')
         self.assertEqual(str(units.Unit('1/s^1/2')), 's^-1/2')

--- a/labrad/units.py
+++ b/labrad/units.py
@@ -517,7 +517,7 @@ class ValueArray(WithUnit):
             return super(ValueArray, cls).__new__(cls, data, unit)
 
         it = iter(data)
-        first = it.next()
+        first = next(it)
         unit = first.unit
         first = first[unit] # convert to float
         rest = [x[unit] for x in it]


### PR DESCRIPTION
The `.next()` method no longer exists in python3. 