### PR TITLE
Fix node internals to avoid losing track of subprocesses

### DIFF
--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -78,19 +78,19 @@ import zipfile
 from configparser import ConfigParser
 from datetime import datetime
 
-from twisted.application.service import MultiService
 from twisted.application.internet import TCPClient
+from twisted.application.service import MultiService
 from twisted.internet import defer, reactor
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.internet.protocol import ProcessProtocol
 from twisted.internet.error import ProcessDone, ProcessTerminated
+from twisted.internet.protocol import ProcessProtocol
 from twisted.python import usage
 from twisted.python.runtime import platformType
 
 import labrad
+import labrad.support
 from labrad import auth, protocol, util, types as T, constants as C
 from labrad.server import LabradServer, setting
-import labrad.support
 from labrad.util import dispatcher, findEnvironmentVars, interpEnvironmentVars
 
 

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -103,9 +103,10 @@ class ServerProcess(ProcessProtocol):
     timeout = 20
     shutdownTimeout = 5
 
-    def __init__(self, env):
+    def __init__(self, env, client):
         self.env = os.environ.copy()
         self.env.update(env, DIR=self.path, FILE=self.filename)
+        self.client = client
         cls = self.__class__
         self.name = interpEnvironmentVars(cls.instancename, self.env)
         self.args = shlex.split(self.cmdline)
@@ -593,9 +594,6 @@ class NodeServer(LabradServer):
         self.credential = credential
         self.servers = {}
         self.instances = {}
-        self.starters = {}
-        self.runners = {}
-        self.stoppers = {}
         self.initMessages(True)
 
     @inlineCallbacks
@@ -608,7 +606,7 @@ class NodeServer(LabradServer):
     def stopServer(self):
         """Stop this node by killing all subprocesses."""
         self.initMessages(False)
-        stoppages = [srv.stop() for srv in self.runners.values()]
+        stoppages = [inst.stop() for inst in self.instances.values()]
         return defer.DeferredList(stoppages)
 
 
@@ -651,26 +649,18 @@ class NodeServer(LabradServer):
 
     def subprocessStarting(self, sender):
         """Called when a subprocess begins connecting."""
-        self.starters[sender.name] = sender
 
     def subprocessStarted(self, sender):
         """Called when a subprocess successfully connects."""
-        if sender.name in self.starters:
-            del self.starters[sender.name]
-        self.runners[sender.name] = sender
 
     def subprocessStopping(self, sender):
         """Called when a subprocess successfully disconnects."""
-        if sender.name in self.runners:
-            del self.runners[sender.name]
-        self.stoppers[sender.name] = sender
 
     def subprocessStopped(self, sender):
         """Called when a subprocess successfully disconnects."""
-        if sender.name in self.runners:
-            del self.runners[sender.name]
-        if sender.name in self.stoppers:
-            del self.stoppers[sender.name]
+        instance_name = sender.name
+        if instance_name in self.instances:
+            del self.instances[instance_name]
 
 
     # status information
@@ -678,12 +668,13 @@ class NodeServer(LabradServer):
     def status(self):
         """Get information about all servers on this node."""
         def serverInfo(cls):
-            instances = [n for n, s in self.runners.items()
-                                    if s.__class__.name == cls.name]
+            instance_names = [inst.name for inst in self.instances.values()
+                                        if inst.__class__.name == cls.name and
+                                           inst.status == 'STARTED']
             return (cls.name, cls.__doc__ or '', cls.version,
-                    cls.instancename, cls.environVars, instances)
-        return [serverInfo(item[1])
-                for item in sorted(self.servers.items())]
+                    cls.instancename, cls.environVars, instance_names)
+        return [serverInfo(server_cls)
+                for server_name, server_cls in sorted(self.servers.items())]
 
 
     # server refresh
@@ -727,7 +718,6 @@ class NodeServer(LabradServer):
                             if conf is None:
                                 continue
                         s = createGenericServerCls(path, f, conf)
-                        s.client = self.client
                         if s.name not in configs:
                             configs[s.name] = {}
                         versions = configs.setdefault(s.name, {})
@@ -780,29 +770,31 @@ class NodeServer(LabradServer):
         if isinstance(self.credential, auth.Password):
             environ.update(LABRADUSER=self.credential.username,
                            LABRADPASSWORD=self.credential.password)
-        srv = self.servers[name](environ)
-        # TODO check whether an instance with this name already exists
-        self.instances[name] = srv
+        srv = self.servers[name](environ, self.client)
+        instance_name = srv.name
+        if instance_name in self.instances:
+            raise Exception("Server '%s' already running." % instance_name)
         yield srv.start()
-        returnValue(srv.name)
+        self.instances[instance_name] = srv
+        returnValue(instance_name)
 
-    @setting(2, name='s', returns='s')
-    def stop(self, c, name):
+    @setting(2, instance_name='s', returns='s')
+    def stop(self, c, instance_name):
         """Stop a running server instance."""
-        if name not in self.runners:
-            raise Exception("'%s' is not running." % name)
-        srv = self.runners[name]
-        yield srv.stop()
-        returnValue(srv.name)
+        if instance_name not in self.instances:
+            raise Exception("'%s' is not running." % instance_name)
+        yield self.instances[instance_name].stop()
+        returnValue(instance_name)
 
-    @setting(3, name='s', returns='s')
-    def restart(self, c, name):
+    @setting(3, instance_name='s', returns='s')
+    def restart(self, c, instance_name):
         """Restart a running server instance."""
-        if name not in self.runners:
-            raise Exception("'%s' is not running." % name)
-        srv = self.runners[name]
-        yield srv.restart()
-        returnValue(srv.name)
+        if instance_name not in self.instances:
+            raise Exception("'%s' is not running." % instance_name)
+        inst = self.instances[instance_name]
+        yield inst.restart()
+        self.instances[instance_name] = inst
+        returnValue(instance_name)
 
     @setting(10, returns='*s')
     def available_servers(self, c):
@@ -815,7 +807,8 @@ class NodeServer(LabradServer):
 
         Returns a list of tuples of server name and instance name.
         """
-        return sorted((s.__class__.name, n) for n, s in self.runners.items())
+        return sorted((s.__class__.name, s.name)
+                      for s in self.instances.values() if s.status == 'STARTED')
 
     @setting(12, returns='*s')
     def local_servers(self, c):
@@ -825,7 +818,7 @@ class NodeServer(LabradServer):
     @setting(13, returns='')
     def refresh_servers(self, c):
         """Refresh the list of available servers."""
-        yield self.refreshServers()
+        self.refreshServers()
 
     @setting(14, 'status',
              returns='*(s{name} s{desc} s{ver} s{instname} *s{vars} *s{running})')
@@ -833,19 +826,19 @@ class NodeServer(LabradServer):
         """Get information about all servers on this node."""
         return self.status()
 
-    @setting(100, name='s', returns='*(ts)')
-    def server_output(self, c, name):
+    @setting(100, instance_name='s', returns='*(ts)')
+    def server_output(self, c, instance_name):
         """Get output from a server's stdout."""
-        if name not in self.runners:
-            raise Exception("'%s' is not running." % name)
-        return self.runners[name].output
+        if instance_name not in self.instances:
+            raise Exception("'%s' is not running." % instance_name)
+        return self.instances[instance_name].output
 
-    @setting(101, name='s', returns='')
-    def clear_output(self, c, name):
+    @setting(101, instance_name='s', returns='')
+    def clear_output(self, c, instance_name):
         """Clear the stdout buffer of a server."""
-        if name not in self.runners:
-            raise Exception("'%s' is not running." % name)
-        self.runners[name].clearOutput()
+        if instance_name not in self.instances:
+            raise Exception("'%s' is not running." % instance_name)
+        self.instances[instance_name].clearOutput()
 
     @setting(102, name='s', returns='s')
     def server_version(self, c, name):
@@ -862,7 +855,6 @@ class NodeServer(LabradServer):
         outputs something on its stdout, effectively giving a
         remote view of the server's console window.
         """
-        pass
 
     @setting(200, returns='')
     def autostart(self, c):
@@ -873,7 +865,7 @@ class NodeServer(LabradServer):
         the node first starts up, but can be invoked manually at any time
         thereafter.
         """
-        running = set(s.__class__.name for s in self.runners.values())
+        running = set(s.__class__.name for s in self.instances.values())
         to_start = [name for name in self.config.autostart
                          if name not in running]
         deferreds = [(name, self.start(c, name)) for name in to_start]

--- a/labrad/node/node_test.py
+++ b/labrad/node/node_test.py
@@ -1,0 +1,132 @@
+from __future__ import absolute_import, print_function
+
+import collections
+import contextlib
+import os
+import subprocess
+import sys
+import time
+
+import labrad
+from labrad.servers import test_server
+
+
+# Directory where test servers are located.
+SERVERS_DIR = os.path.dirname(test_server.__file__)
+
+
+# Infor about node that is yielded by the run_node context manager.
+NodeInfo = collections.namedtuple('NodeInfo', [
+    'node', 'node_name', 'node_server_name', 'node_reg'
+])
+
+
+@contextlib.contextmanager
+def run_node(node_name, cxn, timeout=20):
+    proc = subprocess.Popen([
+        sys.executable,
+        '-m', 'labrad.node',
+        '--name={}'.format(node_name),
+        '--host={}'.format(cxn.host),
+        '--port={}'.format(cxn.port),
+    ])
+    node_server_name = 'node {}'.format(node_name)
+
+    try:
+        start = time.time()
+        while True:
+            cxn.refresh()
+            if node_server_name in cxn.servers:
+                break
+            elapsed = time.time() - start
+            if elapsed > timeout:
+                raise Exception('node failed to start within {} seconds.'
+                                .format(timeout))
+            time.sleep(0.5)
+
+        node_reg = cxn.registry()
+        node_reg.cd(['', 'Nodes', node_name])
+        node_reg.set('autostart', [])
+        node_reg.set('directories', [SERVERS_DIR])
+        node_reg.set('extensions', ['.ini', '.py'])
+
+        node = cxn[node_server_name]
+        node.refresh_servers()
+
+        yield NodeInfo(node, node_name, node_server_name, node_reg)
+    finally:
+        proc.terminate()
+        proc.wait()
+
+
+def check_server(cxn, instance_name, connected):
+    servers = [s for _, s in cxn.manager.servers()]
+    cxn.refresh()
+    assert (instance_name in servers) == connected
+    assert (instance_name in cxn.servers) == connected
+
+
+class TestNode(object):
+
+    def test_node_autodetect(self):
+        with labrad.connect() as cxn:
+            with run_node('test', cxn) as n:
+                servers = n.node.available_servers()
+                assert 'Python Test Server' in servers
+                assert 'Local Python Test Server' in servers
+                n.node_reg.set('directories', [])
+                n.node.refresh_servers()
+                assert n.node.available_servers() == []
+
+    def _test_start_server(self, node_name, name, instance_name, restart=False):
+        with labrad.connect() as cxn:
+            with run_node(node_name, cxn) as n:
+                n.node.start(name)
+                check_server(cxn, instance_name, connected=True)
+                assert cxn[instance_name].echo('woot') == 'woot'
+                if restart:
+                    n.node.restart(instance_name)
+                    check_server(cxn, instance_name, connected=True)
+                    assert cxn[instance_name].echo('yay') == 'yay'
+                n.node.stop(instance_name)
+                check_server(cxn, instance_name, connected=False)
+
+    def test_node_can_start_global_server(self):
+        self._test_start_server(
+            node_name='test',
+            name='Python Test Server',
+            instance_name='Python Test Server'
+        )
+
+    def test_node_can_restart_global_server(self):
+        self._test_start_server(
+            node_name='test',
+            name='Python Test Server',
+            instance_name='Python Test Server',
+            restart=True
+        )
+
+    def test_node_can_start_local_server(self):
+        self._test_start_server(
+            node_name='test',
+            name='Local Python Test Server',
+            instance_name='test Local Python Test Server'
+        )
+
+    def test_node_can_restart_local_server(self):
+        self._test_start_server(
+            node_name='test',
+            name='Local Python Test Server',
+            instance_name='test Local Python Test Server',
+            restart=True
+        )
+
+    def test_node_shuts_down_running_servers_when_stopped(self):
+        with labrad.connect() as cxn:
+            with run_node('test', cxn) as n:
+                n.node.start('Python Test Server')
+                n.node.start('Local Python Test Server')
+                check_server(cxn, 'Python Test Server', connected=True)
+                check_server(cxn, 'test Local Python Test Server', connected=True)
+            check_server(cxn, 'Python Test Server', connected=False)
+            check_server(cxn, 'test Local Python Test Server', connected=False)

--- a/labrad/node/node_test.py
+++ b/labrad/node/node_test.py
@@ -75,6 +75,7 @@ class TestNode(object):
                 assert 'Python Test Server' in servers
                 assert 'Local Python Test Server' in servers
                 n.node_reg.set('directories', [])
+                time.sleep(1)  # TODO(maffoo): get rid of sleep here
                 n.node.refresh_servers()
                 assert n.node.available_servers() == []
 

--- a/labrad/servers/test_server_local.py
+++ b/labrad/servers/test_server_local.py
@@ -1,0 +1,203 @@
+# Copyright (C) 2007  Matthew Neeley
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+### BEGIN NODE INFO
+[info]
+name = Local Python Test Server
+instancename = %LABRADNODE% Local Python Test Server
+version = 1.0.0
+description = Basic python server.
+
+[startup]
+cmdline = %PYTHON% %FILE%
+timeout = 20
+
+[shutdown]
+message = 987654321
+timeout = 5
+### END NODE INFO
+"""
+
+from __future__ import print_function
+
+from labrad import types as T, util
+from labrad.server import LabradServer, setting
+from labrad.units import m, s
+from labrad.util import hydrant
+
+from twisted.internet import defer, reactor
+from twisted.internet.defer import inlineCallbacks, returnValue
+
+
+class LocalTestServer(LabradServer):
+    """Server to test labrad from python.
+
+    This server provides a number of settings that
+    are useful for testing labrad code, network profiling,
+    and testing the python labrad library.
+    """
+    name = 'Local Python Test Server'
+    instanceName = '%LABRADNODE% Local Python Test Server'
+    testMode = True
+    shutdownMessage = 987654321
+
+    @inlineCallbacks
+    def initServer(self):
+        yield None
+        #from registry_wrapper_async import RegistryWrapperAsync
+        #self.regWrapper = yield RegistryWrapperAsync.create(self.client, ['', 'Servers', 'Python Test Server'])
+
+    @inlineCallbacks
+    def stopServer(self):
+        print('before yield')
+        yield None
+        #print (yield self.client.manager.convert_units(T.Value(5, 'GHz'), 'Hz'))
+        print('after yield')
+
+    def serverConnected(self, ID, name):
+        print('server connected:', ID, name)
+        self.checkServerWrappers(name)
+
+    def serverDisconnected(self, ID, name):
+        print('server disconnected:', ID, name)
+        self.checkServerWrappers(name)
+
+    @inlineCallbacks
+    def checkServerWrappers(self, name):
+        """Check that server wrappers are up to date with the manager."""
+        mgrServers = yield self.client.manager.servers()
+        mgrServers = set(s[1] for s in mgrServers)
+        cxnServers = set(self.client.servers.keys())
+        if cxnServers == mgrServers:
+            print('self.client updated for server', name)
+        else:
+            print('self.client not properly refreshed:')
+            print('  servers that should be disconnected:', list(cxnServers - mgrServers))
+            print('  servers that have not been connected:', list(mgrServers - cxnServers))
+
+    def initContext(self, c):
+        c['delay'] = 1*s
+        c['dict'] = {}
+
+    @setting(2, "Delayed Echo", data='?')
+    def delayed_echo(self, c, data):
+        """Echo a packet after a specified delay."""
+        yield util.wakeupCall(c['delay'][s])
+        returnValue(data)
+
+    @setting(3, "Delayed Echo Deferred", data='?')
+    def delayed_echo_deferred(self, c, data):
+        """Echo a packet after a specified delay."""
+        d = defer.Deferred()
+        reactor.callLater(c['delay'][s], d.callback, data)
+        return d
+
+    @setting(4, "Echo Delay", delay='v[s]', returns='v[s]')
+    def echo_delay(self, c, delay=None):
+        """Get or set the echo delay."""
+        self.log('Echo delay: %s' % delay)
+        if delay is not None:
+            c['delay'] = delay
+        return c['delay']
+
+    @setting(40, "Speed", speed='v[m/s]', returns='v[m/s]')
+    def speed(self, c, speed=None):
+        """Get or set the speed."""
+        self.log('Speed: %s' % speed)
+        if speed is not None:
+            c['speed'] = speed
+        return c['speed']
+
+    @setting(41, "Verbose Echo", data='?')
+    def verbose_echo(self, c, data):
+        print(type(data))
+        print(repr(data))
+        return data
+
+    @setting(5, "Exc in Handler", data='?')
+    def exc_in_handler(self, c, data):
+        """Raises an exception directly in the handler."""
+        self.log('Exception in handler.')
+        raise Exception('Raised in handler.')
+
+    @setting(6, "Exc in Subfunction", data='?')
+    def exc_in_subfunction(self, c, data):
+        """Raises an exception in a subfunction."""
+        self.log('Exception in subfunction.')
+        owie()
+
+    @setting(7, "Exc in Deferred", data='?')
+    def exc_in_deferred(self, c, data):
+        """Returns a deferred that fires an exception."""
+        self.log('Exception in deferred.')
+        d = defer.Deferred()
+        d.addCallback(owie)
+        reactor.callLater(c['delay'][s], d.callback, None)
+        return d
+
+    @setting(8, "Exc in Errback", data='?')
+    def exc_in_errback(self, c, data):
+        """Returns a deferred whose errback will be called."""
+        self.log('Exception from an errback.')
+        d = defer.Deferred()
+        reactor.callLater(1, d.errback, Exception('Raised by errback.'))
+        return d
+
+    @setting(9, "Exc in inlineCallback", data='?')
+    def exc_in_inlinecallback(self, c, data):
+        """Raises an exception in an inlineCallback."""
+        self.log('Exception from an inlineCallback.')
+        yield util.wakeupCall(c['delay'][s])
+        raise Exception('Raised in inlineCallback.')
+
+    @setting(10, "Bad Return Type", data='?', returns='s')
+    def bad_return_type(self, c, data):
+        """Returns a value that does not match the declared return type."""
+        return 5
+
+    @setting(11, "Get Random Data", tag='s')
+    def get_random_data(self, c, tag=None):
+        """Get a random bit of data conforming to the specified type tag."""
+        if tag is None:
+            t = hydrant.randType()
+        else:
+            t = T.parseTypeTag(tag)
+        return hydrant.randValue(t)
+
+    @setting(12, "Get Random Tag")
+    def get_random_tag(self, c):
+        """Get a random LabRAD type tag."""
+        return str(hydrant.randType())
+
+    @setting(100, "Set", key='s', value='?', returns='')
+    def set(self, c, key, value):
+        c['dict'][key] = value
+
+    @setting(101, "Get", key='s', returns='?')
+    def get(self, c, key):
+        return c['dict'][key]
+
+    @setting(102, "Keys", returns='*s')
+    def keys(self, c):
+        return sorted(c['dict'].keys())
+
+def owie(dummy=None):
+    raise Exception('Raised in subfunction.')
+
+__server__ = LocalTestServer()
+
+if __name__ == '__main__':
+    util.runServer(__server__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyOpenSSL >= 0.13
 pyparsing >= 2.1.0
 requests
 service_identity
-twisted >= 14.0.0
+twisted >= 16.0.0


### PR DESCRIPTION
Fixes #327 

This cleans up the node internals to make it more robust at tracking subprocesses so that it will not lose track and potentially leave orphan processes around after the node exits. Also adds basic tests of node functionality so that we can continue to refactor the internals with more confidence that we haven't broken anything. Note that I had to bump the minimum twisted version to make tests pass with python 3. I'm looking into whether there's a different way to fix this, but I think that increasing the minimum version shouldn't be too disruptive.