### PR TITLE
Run travis tests against dev versions of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.6-dev"
+  - "3.7-dev"
+matrix:
+  allow_failures:
+  - python: "3.6-dev"
+  - python: "3.7-dev"
 install:
   - cat requirements.txt | perl -p -i -e 's/>=/==/g' > exact_requirements.txt
   - pip install -r exact_requirements.txt


### PR DESCRIPTION
Let's us test against development versions of python 3.6 and 3.7, so we'll be ready when they appear. Build failures on either of these versions won't count as pylabrad build failures, however, since the python dev versions themselves may be broken at times.