### PR TITLE
Clean up ServerProcess implementation

### DIFF
--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -231,7 +231,7 @@ class ServerProcess(ProcessProtocol):
             manager.removeListener(on_server_connect, context=msg_ctx)
             yield manager.subscribe_to_named_message(
                 message, msg_id, False, context=msg_ctx)
-        except Exception as e:
+        except Exception:
             self.logger.info('Error while unsubscribing from labrad messages',
                              exc_info=True)
 

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -73,7 +73,6 @@ import os
 import shlex
 import socket
 import sys
-import weakref
 import zipfile
 from datetime import datetime
 
@@ -91,7 +90,7 @@ import labrad.support
 from labrad import auth, protocol, util, types as T, constants as C
 from labrad.node import server_config
 from labrad.server import LabradServer, setting
-from labrad.util import interpEnvironmentVars
+from labrad.util import DeferredSignal, interpEnvironmentVars, mux
 
 
 LOG_LENGTH = 1000 # maximum number of lines of stdout to keep per server
@@ -100,8 +99,13 @@ LOG_LENGTH = 1000 # maximum number of lines of stdout to keep per server
 class ServerProcess(ProcessProtocol):
     """A class to represent a running server instance."""
 
-    timeout = 20
-    shutdownTimeout = 5
+    # Messages that will be fired when we transition to various statuses
+    STATUS_MESSAGES = {
+        'STARTING': 'server_starting',
+        'STARTED': 'server_started',
+        'STOPPING': 'server_stopping',
+        'STOPPED': 'server_stopped',
+    }
 
     def __init__(self, config, env, client, on_message):
         """Initialize a ServerProcess instance.
@@ -130,14 +134,15 @@ class ServerProcess(ProcessProtocol):
         self.name = interpEnvironmentVars(config.instance_name, self.full_env)
         self.args = shlex.split(config.cmdline)
         self.args = [interpEnvironmentVars(a, self.full_env) for a in self.args]
-        self.starting = False
-        self.started = False
-        self.stopping = False
+        self.status = None
         self.output = []
         self.on_message = on_message
         self._lock = defer.DeferredLock()
         logname = 'labrad.' + labrad.support.mangle(self.name)
         self.logger = logging.getLogger(logname)
+
+        # Signal that will fire when the server process is shutdown.
+        self.on_shutdown = DeferredSignal()
 
     @property
     def server_name(self):
@@ -181,137 +186,133 @@ class ServerProcess(ProcessProtocol):
         else:
             raise RuntimeError("Unsupported platform %s" % platformType)
 
-    @property
-    def status(self):
-        if self.starting:
-            return 'STARTING'
-        elif self.started:
-            return 'STARTED'
-        elif self.stopping:
-            return 'STOPPING'
-        else:
-            return 'STOPPED'
+    def set_status(self, value):
+        """Transition to the given status and notify message listeners."""
+        message = self.STATUS_MESSAGES[value]
+        self.status = value
+        self.logger.info(value)
+        self.on_message(self, message)
 
+    @inlineCallbacks
     def start(self):
-        """Start this server instance."""
-        return self._lock.run(self._start)
+        self.set_status('STARTING')
+        self.logger.info("path: {}".format(self.path))
+        self.logger.info("args: {}".format(self.args))
+
+        # start listening for server connect messages
+        msg_ctx = self.client.context()
+        msg_id = msg_ctx[1]
+
+        connected = defer.Deferred()
+
+        def on_server_connect(message_ctx, msg):
+            _ID, name = msg
+            if name == self.name:
+                connected.callback(None)
+
+        message = 'Server Connect'
+        manager = self.client.manager
+        manager.addListener(on_server_connect, context=msg_ctx)
+        yield manager.subscribe_to_named_message(
+            message, msg_id, True, context=msg_ctx)
+
+        # start the server process
+        self.proc = reactor.spawnProcess(self, self.executable, self.args,
+                                         env=self.full_env, path=self.path)
+
+        # wait for the server to connect, shutdown, or timeout
+        selected = yield mux.select(
+            connected=connected,
+            shutdown=self.on_shutdown(),
+            timeout=self.timeout)
+
+        # stop listening for server connect messages
+        try:
+            manager.removeListener(on_server_connect, context=msg_ctx)
+            yield manager.subscribe_to_named_message(
+                message, msg_id, False, context=msg_ctx)
+        except Exception as e:
+            self.logger.info('Error while unsubscribing from labrad messages',
+                             exc_info=True)
+
+        if selected('timeout'):
+            yield self._kill()
+            raise T.Error('Failed to connect to labrad in {} seconds.'
+                          .format(self.timeout), payload=self.output)
+        if selected('shutdown'):
+            raise T.Error('Process exited before connecting to labrad.',
+                          payload=self.output)
+
+        # we're connected!
+        self.set_status('STARTED')
 
     def stop(self):
-        """Stop this server instance."""
+        """Stop this server instance.
+
+        We protect this with a lock so that multiple calls to stop the server
+        will not interfere with each other. Rather, subsequent calls to stop
+        will wait for the initial call to finish before returning.
+        """
         return self._lock.run(self._stop)
 
     @inlineCallbacks
-    def _start(self):
-        if self.started:
+    def _stop(self):
+        if self.status == 'STOPPED':
             return
-        print("starting '%s'..." % self.name)
-        print("path:", self.path)
-        print("args:", self.args)
-        self.starting = True
-        self.startup = defer.Deferred()
-        self.emitMessage('server_starting')
-        self.proc = reactor.spawnProcess(self, self.executable, self.args,
-                                         env=self.full_env, path=self.path)
-        timeoutCall = reactor.callLater(self.timeout, self.kill)
-        try:
-            yield self.startup
-            self.emitMessage('server_started')
-        except:
-            self.emitMessage('server_stopped')
-            raise
-        finally:
-            self.starting = False
-            if timeoutCall.active():
-                timeoutCall.cancel()
+
+        self.set_status('STOPPING')
+
+        if self.config.shutdown_mode is not None:
+            # Try to do an orderly shutdown.
+            mode, ID = self.config.shutdown_mode
+            if mode == 'message':
+                try:
+                    self.client.servers[self.name].sendMessage(ID)
+                except:
+                    self.logger.info('Error while shutting down with message',
+                                     exc_info=True)
+            elif mode == 'setting':
+                try:
+                    yield self.client.servers[self.name][ID]()
+                except:
+                    self.logger.info('Error while shutting down with setting',
+                                     exc_info=True)
+
+            selected = yield mux.select(
+                shutdown=self.on_shutdown(),
+                timeout=self.config.shutdown_timeout)
+
+            if selected('shutdown'):
+                return
+
+        # Shutdown failed or not configured, so just kill the process.
+        yield self._kill()
 
     @inlineCallbacks
-    def _stop(self):
-        if not self.started:
-            return
-        print("stopping '%s'..." % self.name)
-        self.stopping = True
-        self.shutdown = defer.Deferred()
-        self.emitMessage('server_stopping')
-        # hack: marker to tell the kill func that it worked
-        finished = [False]
-        self.kill(finished)
-        yield self.shutdown
-        finished[0] = True
-        self.stopping = False
-        self.emitMessage('server_stopped')
+    def _kill(self):
+        """Send a signal to kill the subprocess and wait for it to exit."""
+        try:
+            self.proc.signalProcess('KILL')
+        except:
+            self.logger.error('Error killing subprocess', exc_info=True)
+        yield self.on_shutdown()
 
-    def emitMessage(self, msg):
-        """Emit a message to other parts of this application."""
-        self.on_message(self, msg)
-
-    def serverConnected(self, ID, name):
-        """Called when a server connects to LabRAD.
-
-        If the name matches our name, we'll assume this server
-        started successfully.  This may not be the case (e.g. if
-        two nodes are trying to start the same server simultaneously),
-        but there's no way to find out from LabRAD which node
-        a given server is running on, so this will have to do.
-        """
-        if name == self.name:
-            self.ID = ID
-            if self.starting:
-                self.started = True
-                self.startup.callback(self)
+    # ProcessProtocol callbacks called by the subprocess.
 
     def processEnded(self, reason):
         """Called when the server process ends.
 
-        We check to see the reason why this process failed, and then
-        call the appropriate deferred, depending on the current state.
+        We set the status to STOPPED and call the shutdown callback to notify
+        anyone waiting for us to shutdown.
         """
         if isinstance(reason.value, ProcessDone):
-            print("'%s': process closed cleanly." % self.name)
+            self.logger.info("process closed cleanly.")
         elif isinstance(reason.value, ProcessTerminated):
-            print("'%s': process terminated: %s" % (self.name, reason.value))
+            self.logger.info("process terminated: {}".format(reason.value))
         else:
-            print("'%s': process ended: %s" % (self.name, reason))
-        self.started = False
-        if self.starting:
-            err = T.Error('Startup failed.', payload=self.output)
-            self.startup.errback(err)
-        elif self.stopping:
-            self.shutdown.callback(None)
-        else:
-            # looks like this thing died on its own
-            self.emitMessage('server_stopped')
-
-    @inlineCallbacks
-    def kill(self, finished=None):
-        """Kill the server process."""
-        if not self.started:
-            return
-        try:
-            servers = self.client.servers
-            if hasattr(self, 'shutdownMode') and self.name in servers:
-                mode, ID = self.shutdownMode
-                if mode == 'message':
-                    # try to shutdown by sending a message
-                    servers[self.name].sendMessage(ID)
-                elif mode == 'setting':
-                    # try to shutdown by calling a setting
-                    try:
-                        yield servers[self.name][ID]()
-                    except:
-                        pass
-                yield util.wakeupCall(self.shutdownTimeout)
-
-            # hack to let us know that we did indeed finish killing the server
-            if finished is not None:
-                if finished[0]:
-                    return
-
-            # if we're not dead yet, kill with a vengeance
-            if self.started:
-                self.proc.signalProcess('KILL')
-        except Exception:
-            logging.error('Error while trying to kill server process for "%s":' % self.name,
-                          exc_info=True)
+            self.logger.info("process ended: {}".format(reason))
+        self.set_status('STOPPED')
+        self.on_shutdown.callback()
 
     def outReceived(self, data):
         """Called when the server prints to stdout."""
@@ -531,17 +532,6 @@ class NodeServer(LabradServer):
         # stopped.
         self.instances = {}
 
-        # ServerProcess instances that will be notified when new servers connect
-        # to labrad. ServerProcesses use this information to determine when the
-        # subprocesses that they launch have successfully connected to labrad.
-        # We use a separate collection here than self.instances because
-        # ServerProcess instances need to receive the server connection
-        # notification in order to startup, but they are not added to
-        # self.instances until after they have started up successfully.
-        # TODO: ServerProcess instances should manage notifications on their
-        # own, since they have access to a labrad client.
-        self.instances_to_notify = weakref.WeakSet()
-
     @inlineCallbacks
     def initServer(self):
         """Initialize this server after connecting to the labrad manager."""
@@ -569,10 +559,6 @@ class NodeServer(LabradServer):
                 messages to notify interested listeners, such as the node web
                 interface.
         """
-        if message == 'server_stopped':
-            instance_name = sender.name
-            if instance_name in self.instances:
-                del self.instances[instance_name]
         self._relayMessage(message, server=sender.server_name,
                            instance=sender.name)
 
@@ -581,11 +567,6 @@ class NodeServer(LabradServer):
         kw['node'] = self.name
         mgr = self.client.manager
         mgr.send_named_message('node.' + signal, tuple(kw.items()))
-
-    def serverConnected(self, ID, name):
-        """Called when a server connects to LabRAD."""
-        for inst in self.instances_to_notify:
-            inst.serverConnected(ID, name)
 
 
     # status information
@@ -699,28 +680,45 @@ class NodeServer(LabradServer):
         instance_name = srv.name
         if instance_name in self.instances:
             raise Exception("Server '%s' already running." % instance_name)
-        self.instances_to_notify.add(srv)
         yield srv.start()
         self.instances[instance_name] = srv
+
+        # remove instance from instance dict when it shuts down
+        @inlineCallbacks
+        def handle_shutdown():
+            yield srv.on_shutdown()
+            self._remove_instance(instance_name)
+        handle_shutdown()
+
         returnValue(instance_name)
 
     @setting(2, instance_name='s', returns='s')
     def stop(self, c, instance_name):
         """Stop a running server instance."""
-        if instance_name not in self.instances:
-            raise Exception("'%s' is not running." % instance_name)
-        yield self.instances[instance_name].stop()
+        yield self._stop(instance_name)
         returnValue(instance_name)
 
     @setting(3, instance_name='s', returns='s')
     def restart(self, c, instance_name):
         """Restart a running server instance."""
+        inst = yield self._stop(instance_name)
+        yield self.start(c, inst.server_name, inst.env)
+        returnValue(instance_name)
+
+    @inlineCallbacks
+    def _stop(self, instance_name):
+        """Stop a running server instance, and return the instance."""
         if instance_name not in self.instances:
             raise Exception("'%s' is not running." % instance_name)
         inst = self.instances[instance_name]
         yield inst.stop()
-        yield self.start(c, inst.server_name, inst.env)
-        returnValue(instance_name)
+        # ensure instance is removed from instance dict before we return
+        self._remove_instance(instance_name) 
+        returnValue(inst)
+
+    def _remove_instance(self, instance_name):
+        if instance_name in self.instances:
+            del self.instances[instance_name]
 
     @setting(10, returns='*s')
     def available_servers(self, c):

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -93,7 +93,12 @@ from labrad.server import LabradServer, setting
 from labrad.util import DeferredSignal, interpEnvironmentVars, mux
 
 
-LOG_LENGTH = 1000 # maximum number of lines of stdout to keep per server
+# Maximum number of lines of stdout to keep per server.
+LOG_LENGTH = 1000
+
+
+# Named message fired by the manager when new servers connect.
+SERVER_CONNECTED = 'Server Connect'
 
 
 class ServerProcess(ProcessProtocol):
@@ -210,11 +215,10 @@ class ServerProcess(ProcessProtocol):
             if name == self.name:
                 connected.callback(None)
 
-        message = 'Server Connect'
         manager = self.client.manager
         manager.addListener(on_server_connect, context=msg_ctx)
         yield manager.subscribe_to_named_message(
-            message, msg_id, True, context=msg_ctx)
+            SERVER_CONNECTED, msg_id, True, context=msg_ctx)
 
         # start the server process
         self.proc = reactor.spawnProcess(self, self.executable, self.args,
@@ -230,7 +234,7 @@ class ServerProcess(ProcessProtocol):
         try:
             manager.removeListener(on_server_connect, context=msg_ctx)
             yield manager.subscribe_to_named_message(
-                message, msg_id, False, context=msg_ctx)
+                SERVER_CONNECTED, msg_id, False, context=msg_ctx)
         except Exception:
             self.logger.info('Error while unsubscribing from labrad messages',
                              exc_info=True)

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -235,11 +235,11 @@ class ServerProcess(ProcessProtocol):
             self.logger.info('Error while unsubscribing from labrad messages',
                              exc_info=True)
 
-        if selected('timeout'):
+        if selected.key == 'timeout':
             yield self._kill()
             raise T.Error('Failed to connect to labrad in {} seconds.'
                           .format(self.timeout), payload=self.output)
-        if selected('shutdown'):
+        if selected.key == 'shutdown':
             raise T.Error('Process exited before connecting to labrad.',
                           payload=self.output)
 
@@ -282,7 +282,7 @@ class ServerProcess(ProcessProtocol):
                 shutdown=self.on_shutdown(),
                 timeout=self.config.shutdown_timeout)
 
-            if selected('shutdown'):
+            if selected.key == 'shutdown':
                 return
 
         # Shutdown failed or not configured, so just kill the process.

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -211,6 +211,12 @@ class ServerProcess(ProcessProtocol):
         connected = defer.Deferred()
 
         def on_server_connect(message_ctx, msg):
+            """Handler that will be called when labrad servers connect.
+
+            If we see a server whose name matches the one we are trying to
+            start, we assume that the server process we spawned has successfully
+            connected. So, we fire the `connected` Deferred.
+            """
             _ID, name = msg
             if name == self.name:
                 connected.callback(None)
@@ -224,7 +230,8 @@ class ServerProcess(ProcessProtocol):
         self.proc = reactor.spawnProcess(self, self.executable, self.args,
                                          env=self.full_env, path=self.path)
 
-        # wait for the server to connect, shutdown, or timeout
+        # wait for the server to connect to labrad, shutdown, or timeout,
+        # whichever comes first.
         selected = yield mux.select(
             connected=connected,
             shutdown=self.on_shutdown(),

--- a/labrad/node/__init__.py
+++ b/labrad/node/__init__.py
@@ -200,10 +200,6 @@ class ServerProcess(ProcessProtocol):
         """Stop this server instance."""
         return self._lock.run(self._stop)
 
-    def restart(self):
-        """Restart this server instance."""
-        return self._lock.run(self._restart)
-
     @inlineCallbacks
     def _start(self):
         if self.started:
@@ -243,11 +239,6 @@ class ServerProcess(ProcessProtocol):
         finished[0] = True
         self.stopping = False
         self.emitMessage('server_stopped')
-
-    @inlineCallbacks
-    def _restart(self):
-        yield self._stop()
-        yield self._start()
 
     def emitMessage(self, msg):
         """Emit a message to other parts of this application."""
@@ -727,8 +718,8 @@ class NodeServer(LabradServer):
         if instance_name not in self.instances:
             raise Exception("'%s' is not running." % instance_name)
         inst = self.instances[instance_name]
-        yield inst.restart()
-        self.instances[instance_name] = inst
+        yield inst.stop()
+        yield self.start(c, inst.server_name, inst.env)
         returnValue(instance_name)
 
     @setting(10, returns='*s')

--- a/labrad/node/server_config.py
+++ b/labrad/node/server_config.py
@@ -20,9 +20,9 @@ class ServerConfig(object):
         self.cmdline = cmdline
         self.path = path
         self.filename = filename
-        self.timeout = timeout
+        self.timeout = 20 if timeout is None else timeout
         self.shutdown_mode = shutdown_mode
-        self.shutdown_timeout = shutdown_timeout
+        self.shutdown_timeout = 5 if shutdown_timeout is None else shutdown_timeout
 
 
 def from_string(conf, filename=None, path=None, platform=sys.platform):
@@ -62,6 +62,8 @@ def from_string(conf, filename=None, path=None, platform=sys.platform):
         shutdown_mode = 'message', int(scp.get('shutdown', 'message', raw=True))
     elif scp.has_option('shutdown', 'setting'):
         shutdown_mode = 'setting', scp.get('shutdown', 'setting', raw=True)
+    else:
+        shutdown_mode = None
     try:
         shutdown_timeout = float(scp.getint('shutdown', 'timeout'))
     except:

--- a/labrad/util/mux.py
+++ b/labrad/util/mux.py
@@ -1,0 +1,66 @@
+from twisted.internet import defer
+
+from labrad import util
+
+
+def select(**kwargs):
+    """Select from among a set of Deferreds the first one that fires.
+
+    Args:
+        **kwargs: Map from key name (str) to Deferred. The key associated with
+            the first Deferred that fires will be returned in the resulting
+            Selection to identify which one fired. In addition to Deferreds,
+            the special keyword arg 'timeout' can be specified as a number
+            giving a timeout in seconds. This will cause the selection to
+            timeout if none of the other provided Deferreds fire before the
+            specified time elapses.
+
+    Returns:
+        (Deferred[Selection]): A Deferred that will fire with a Selection that
+        contains the key of the selected Deferred and the resulting value or
+        error.
+    """
+    if 'timeout' in kwargs:
+        kwargs['timeout'] = util.wakeupCall(kwargs['timeout'])
+    result = defer.Deferred()
+    @defer.inlineCallbacks
+    def handle(key, deferred):
+        try:
+            value = yield deferred
+            try:
+                result.callback(Selection(key, value))
+            except defer.AlreadyCalledError:
+                pass
+        except Exception as e:
+            try:
+                result.callback(Selection(key, error=e))
+            except defer.AlreadyCalledError:
+                pass
+    for key, deferred in kwargs.items():
+        handle(key, deferred)
+    return result
+
+
+class Selection(object):
+    """The result of the first firing Deferred from a call to select."""
+    def __init__(self, key, value=None, error=None):
+        self.key = key
+        self.value = value
+        self.error = error
+
+    def __call__(self, key):
+        """Check if the selection key matches the given key.
+
+        Args:
+            key (str): The key to compare against the selected key.
+
+        Returns:
+            (bool): True if the given key matches what was selected, else False.
+        """
+        return key == self.key
+
+    def result(self):
+        """Get the result (or raise the error) from the selected Deferred."""
+        if self.error is not None:
+            raise self.error
+        return self.value

--- a/labrad/util/mux.py
+++ b/labrad/util/mux.py
@@ -48,17 +48,6 @@ class Selection(object):
         self.value = value
         self.error = error
 
-    def __call__(self, key):
-        """Check if the selection key matches the given key.
-
-        Args:
-            key (str): The key to compare against the selected key.
-
-        Returns:
-            (bool): True if the given key matches what was selected, else False.
-        """
-        return key == self.key
-
     def result(self):
         """Get the result (or raise the error) from the selected Deferred."""
         if self.error is not None:

--- a/labrad/util/mux.py
+++ b/labrad/util/mux.py
@@ -45,13 +45,13 @@ def select(options):
 
 class Selection(object):
     """The result of the first firing Deferred from a call to select."""
-    def __init__(self, key, value=None, error=None):
+    def __init__(self, key, result=None, error=None):
         self.key = key
-        self.value = value
-        self.error = error
+        self._result = result
+        self._error = error
 
     def result(self):
         """Get the result (or raise the error) from the selected Deferred."""
-        if self.error is not None:
-            raise self.error
-        return self.value
+        if self._error is not None:
+            raise self._error
+        return self._result


### PR DESCRIPTION
Changes the way ServerProcess works so that an individual ServerProcess instance cannot be restarted. If we want to restart a server we stop the existing instance and then create and start a new instance. This means that the new instance will pick up newer configuration if the node configs have been refreshed (Fixes #303). This also makes it much more straightforward to manage the lifecycle of ServerProcess instances, because once one stops it will never start again, so it can be removed from the node's instances dict and won't be re-added.

This change also lets us clean up the internals of the ServerProcess implementation, in particular the way it communicates with the subprocess, which should make things much more stable. We also move the code to listen for labrad server connect instances into ServerProcess itself; that means the node does not have to keep track of instances to notify in the hacky `instance_to_notify` set, and in addition the ServerProcess can listen for messages only during the time when it cares about messages, namely while attempting to startup.