### PR TITLE
Add support for dealing with outdated servers in the node

### DIFF
--- a/labrad/node/server_config.py
+++ b/labrad/node/server_config.py
@@ -10,7 +10,7 @@ from labrad.util import findEnvironmentVars
 class ServerConfig(object):
     def __init__(self, name, description, version, instance_name, cmdline, path,
                  filename, timeout, shutdown_mode, shutdown_timeout):
-        self.name = name
+        self.name = self.base_name = name
         self.description = description
         self.version = version
         self.version_tuple = version_tuple(version)

--- a/labrad/test/util.py
+++ b/labrad/test/util.py
@@ -1,0 +1,11 @@
+import contextlib
+import shutil
+import tempfile
+
+@contextlib.contextmanager
+def temp_directory():
+    path = tempfile.mkdtemp()
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)


### PR DESCRIPTION
By "outdated" servers we mean running servers for which a newer version is available to launch. We add settings to get a information about outdated servers and to restart all outdated servers.

@zchen088, @kunalq 