### PR TITLE
fix IPython autocomplete in python 3

### DIFF
--- a/labrad/client.py
+++ b/labrad/client.py
@@ -239,7 +239,9 @@ class HasDynamicAttrs(object):
         """Return a list of attributes for tab-completion.
         """
         self.refresh() # force refresh so the list is current
-        return sorted(set(self._attrs.keys() + self.__dict__.keys() + dir(type(self))))
+        return sorted(set(list(self._attrs.keys())
+                          + list(self.__dict__.keys())
+                          + dir(type(self))))
     
     def __getattr__(self, key):
         try:


### PR DESCRIPTION
Addresses #355. `list()` is called on the generator object returned by `keys()` so they can be concatenated. This should fix the IPython autocomplete problem in python 3.