### PR TITLE
rename async for python 3.7 compatability

### DIFF
--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -287,7 +287,7 @@ class LabradProtocol(protocol.Protocol):
                               for i in (ID, None)
                               if (s, c, i) in self.listeners)
             for key in keys:
-                for listener, async in self.listeners[key]:
+                for listener, sync in self.listeners[key]:
                     func, args, kw = listener
                     @inlineCallbacks
                     def call_handler():
@@ -298,24 +298,24 @@ class LabradProtocol(protocol.Protocol):
                                   msgCtx, data, listener)
                             traceback.print_exc()
                     d = call_handler()
-                    if not async:
+                    if sync:
                         yield d
 
     # message handling
-    def addListener(self, listener, source=None, context=None, ID=None, async=True, args=(), kw={}):
+    def addListener(self, listener, source=None, context=None, ID=None, sync=False, args=(), kw={}):
         """Add a listener for messages with the specified attributes.
 
         When a message with the specified source, context and ID is received,
         listener will be called with the message data, along with the args and
-        keyword args specified here.  async determines how message listeners
-        that return deferreds are to be handled.  If async is True, the message
+        keyword args specified here.  sync determines how message listeners
+        that return deferreds are to be handled.  If sync is False, the message
         dispatcher will not wait for the deferred returned by a listener to fire.
-        However, if async is False, the dispatcher will wait for this deferred
+        However, if sync is True, the dispatcher will wait for this deferred
         before firing any more messages.
         """
         key = (source, context, ID)
         listeners = self.listeners.setdefault(key, [])
-        listeners.append(((listener, args, kw), async))
+        listeners.append(((listener, args, kw), sync))
 
     def removeListener(self, listener, source=None, context=None, ID=None):
         """Remove a listener for messages."""

--- a/labrad/protocol.py
+++ b/labrad/protocol.py
@@ -302,7 +302,7 @@ class LabradProtocol(protocol.Protocol):
                         yield d
 
     # message handling
-    def addListener(self, listener, source=None, context=None, ID=None, sync=False, args=(), kw={}):
+    def addListener(self, listener, source=None, context=None, ID=None, sync=False, args=(), kw={}, **kwargs):
         """Add a listener for messages with the specified attributes.
 
         When a message with the specified source, context and ID is received,
@@ -313,6 +313,13 @@ class LabradProtocol(protocol.Protocol):
         However, if sync is True, the dispatcher will wait for this deferred
         before firing any more messages.
         """
+        # this function used to have an async parameter with inverted logic to
+        # the current sync parameter. This had to be changed as python 3.7 made
+        # async a keyword. This workaround allows to maintain the old API for
+        # older python versions.
+        if 'async' in kwargs:
+            sync = not kwargs['async']
+
         key = (source, context, ID)
         listeners = self.listeners.setdefault(key, [])
         listeners.append(((listener, args, kw), sync))

--- a/labrad/server.py
+++ b/labrad/server.py
@@ -417,8 +417,8 @@ class LabradServer(object):
         # sign up for notifications from the manager
         yield mgr.subscribe_to_named_message('Server Connect', 55443322, True)
         yield mgr.subscribe_to_named_message('Server Disconnect', 66554433, True)
-        self._cxn.addListener(self._serverConnected, source=mgr.ID, ID=55443322, async=False)
-        self._cxn.addListener(self._serverDisconnected, source=mgr.ID, ID=66554433, async=False)
+        self._cxn.addListener(self._serverConnected, source=mgr.ID, ID=55443322, sync=True)
+        self._cxn.addListener(self._serverDisconnected, source=mgr.ID, ID=66554433, sync=True)
 
         #yield mgr.notify_on_connect.connect(self._serverConnected)
         #yield mgr.notify_on_disconnect.connect(self._serverDisconnected)

--- a/labrad/wrappers.py
+++ b/labrad/wrappers.py
@@ -460,8 +460,8 @@ class ClientAsync(object):
         try:
             yield self._mgr.subscribeToNamedMessage('Server Connect', 314159265, True)
             yield self._mgr.subscribeToNamedMessage('Server Disconnect', 314159266, True)
-            self._cxn.addListener(self._serverConnected, source=self._mgr.ID, ID=314159265, async=False)
-            self._cxn.addListener(self._serverDisconnected, source=self._mgr.ID, ID=314159266, async=False)
+            self._cxn.addListener(self._serverConnected, source=self._mgr.ID, ID=314159265, sync=True)
+            self._cxn.addListener(self._serverDisconnected, source=self._mgr.ID, ID=314159266, sync=True)
             yield self.refresh()
         except Exception as e:
             print('error!')

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Topic :: Scientific/Engineering"""
 
 import os


### PR DESCRIPTION
async has become a keyword in python 3.7 (see [what's new](https://docs.python.org/3.7/whatsnew/3.7.html)), making the current version unusable in 3.7. This renames `async` to `_async` at the relevant locations, even though I am up for any other name.
This creates a breaking change in the API as it used in the parameter list of `LabradProtocol.addListener`.