### PR TITLE
Update python3 versions used for travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
   - "3.8-dev"
 matrix:
   allow_failures:
+  - python: "3.7-dev"
   - python: "3.8-dev"
 install:
   - cat requirements.txt | perl -p -i -e 's/>=/==/g' > exact_requirements.txt


### PR DESCRIPTION
Add 3.7 and 3.8-dev