### PR TITLE
use bytearray instead of bytes to avoiding copying the data.

### DIFF
--- a/labrad/stream.py
+++ b/labrad/stream.py
@@ -10,21 +10,26 @@ def packetStream(packetHandler, endianness='>'):
     Accepts a function packetHandler that will be called with four arguments
     whenever a packet is completed: source, context, request, records.
     """
-    buf = b''
+    # buf = b''
+    buf = bytearray()
     while True:
         # get packet header (20 bytes)
         while len(buf) < 20:
-            buf += yield 0
+            # buf += yield 0
+            data = yield 0
+            buf.extend(bytearray(data))
         hdr, buf = buf[:20], buf[20:]
-        context, request, source, length = T.unflatten(hdr, HEADER_TYPE, endianness=endianness)
+        context, request, source, length = T.unflatten(bytes(hdr), HEADER_TYPE, endianness=endianness)
 
         # get packet data
         while len(buf) < length:
-            buf += yield 0
+            # buf += yield 0
+            data = yield 0
+            buf.extend(bytearray(data))
         s, buf = buf[:length], buf[length:]
 
         # unflatten the data
-        records = unflattenRecords(s, endianness=endianness)
+        records = unflattenRecords(bytes(s), endianness=endianness)
 
         packetHandler(source, context, request, records)
 
@@ -70,4 +75,3 @@ def flattenRecord(ID, data, types=[], endianness='>'):
     flat_record = RECORD_TYPE.flatten((ID, str(flat.tag), bytes(flat.bytes)),
                                       endianness)
     return flat_record.bytes
-


### PR DESCRIPTION
I find the labrad system takes a long time transfer a large packet, which is noted in the issue #220. 
With the same test written by @maffoo , I test this new packetStream, with the following code.
```python
def setting_time(n, cxn, server='manager'):
    s = bytes(bytearray(n))
    ti = time.time()
    cxn[server].echo(s)
    te = time.time()
    return te - ti
def main()
    print("Manager: ")
    with labrad.connect() as cxn:
        for x in range(20, 30):
            print(x, setting_time(2**x, cxn))
    print("Test Server: ")
    with labrad.connect() as cxn:
        for x in range(20, 30):
            print(x, setting_time(2**x, cxn, server='python_test_server'))
main()
```
Here is the result:
```
Manager:               
20 0.02391362190246582 
21 0.02747058868408203 
22 0.06482601165771484 
23 0.10375523567199707 
24 0.19747138023376465 
25 0.40491795539855957 
26 0.8242068290710449  
27 1.6051926612854004  
28 3.589486837387085   
29 10.249689817428589  
Test Server:           
20 0.04089021682739258 
21 0.1296536922454834  
22 0.11968016624450684 
23 0.21642041206359863 
24 0.4168851375579834  
25 1.0563695430755615  
26 1.7875730991363525  
27 4.136369943618774   
28 9.051634311676025   
29 17.714696407318115  
```

The old packetStream (using bytes) (only to 2**26, as it takes too much time)
```
Manager:                
20 0.019945859909057617 
21 0.03984975814819336  
22 0.11771774291992188  
23 0.530127763748169    
24 1.2997245788574219   
25 5.040466547012329    
26 19.881891012191772   
Test Server:            
20 0.03687715530395508  
21 0.07280373573303223  
22 0.19045782089233398  
23 0.6843514442443848   
24 2.4629600048065186   
25 9.668785810470581    
26 37.53484034538269    
```