### PR TITLE
Correct numpy requirement for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   allow_failures:
   - python: "3.9-dev"
 install:
-  - cat requirements.txt | perl -p -i -e 's/>=/==/' > exact_requirements.txt
+  - sed 's/>=/==/' requirements.txt > exact_requirements.txt
   - pip install -r exact_requirements.txt
   - pip install .
   - pip install pytest coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   allow_failures:
   - python: "3.9-dev"
 install:
-  - cat requirements.txt | perl -p -i -e 's/>=/==/g' > exact_requirements.txt
+  - cat requirements.txt | perl -p -i -e 's/>=/==/' > exact_requirements.txt
   - pip install -r exact_requirements.txt
   - pip install .
   - pip install pytest coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ configparser
 future
 futures >= 3.0.*
 numpy >= 1.12.*; python_version < '3.7'
-numpy >= 1.15.*; python_version >= '3.7'
+numpy >= 1.15.*; python_version == '3.7'
+numpy >= 1.17.*; python_version >= '3.8'
 pyOpenSSL >= 16.2.*
 pyparsing >= 2.1.*
 requests


### PR DESCRIPTION
PR in response to a couple things I've found while setting up my environment:

---

The substitution command https://github.com/labrad/pylabrad/blob/3c2f9d98c93ae46e486b4b94ca0603c71a38b7b1/.travis.yml#L16

doesn't work properly with the line https://github.com/labrad/pylabrad/blob/3c2f9d98c93ae46e486b4b94ca0603c71a38b7b1/requirements.txt#L6

It will result in not installing numpy at all if Python >= 3.8. This can be fixed by removing the global flag `/g`.

This doesn't cause issues in Travis since Travis preinstalls numpy (e.g. see line 283 [here](https://travis-ci.org/github/labrad/pylabrad/jobs/690534373#L283)).

---

If using Python 3.8 and installing packages per exact_requirements.txt (with the corrected global flag per above), I get errors like the following when running tests:

```
____________________________________ ERROR collecting labrad/node/node_test.py _____________________________________
ImportError while importing test module '/home/ganden/vc/labrad/pylabrad/labrad/node/node_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/core/__init__.py:16: in <module>
    from . import multiarray
E   ImportError: /home/ganden/.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/core/multiarray.cpython-38-x86_64-linux-gnu.so: undefined symbol: cblas_sgemm

During handling of the above exception, another exception occurred:
labrad/__init__.py:20: in <module>
    from labrad import backend, client, constants
labrad/backend.py:14: in <module>
    from labrad import concurrent, constants as C, support, thread, types as T
labrad/types/__init__.py:1: in <module>
    from labrad.types.types import Buffer
labrad/types/types.py:44: in <module>
    import numpy as np
../../../.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/__init__.py:142: in <module>
    from . import add_newdocs
../../../.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/add_newdocs.py:13: in <module>
    from numpy.lib import add_newdoc
../../../.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/lib/__init__.py:8: in <module>
    from .type_check import *
../../../.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/lib/type_check.py:11: in <module>
    import numpy.core.numeric as _nx
../../../.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/core/__init__.py:26: in <module>
    raise ImportError(msg)
E   ImportError: 
E   Importing the multiarray numpy extension module failed.  Most
E   likely you are trying to import a failed build of numpy.
E   If you're working with a numpy git repo, try `git clean -xdf` (removes all
E   files not under version control).  Otherwise reinstall numpy.
E   
E   Original error was: /home/ganden/.pyenv/versions/3.8.2/envs/pylabrad-38/lib/python3.8/site-packages/numpy/core/multiarray.cpython-38-x86_64-linux-gnu.so: undefined symbol: cblas_sgemm
```

This is fixed by installing `numpy >= 1.17.*` instead of `numpy == 1.15.*`.