### PR TITLE
Remove attrs from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-attrs >= 19.1.*
 configparser
 future
 futures >= 3.0.*


### PR DESCRIPTION
We don't depend on this directly---it is a subdependency that we depend on via other packages. In normal usage of requirements.txt this line would not cause issues. However, this line causes issues when used with a later Twisted version (e.g. 18.7) due to the sed in .travis.yml. We should probably remove this line unless there is a specific reason to keep it that I have missed (see #364).