### PR TITLE
Add Python version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pylabrad
 
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pylabrad)
+![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)
 [![PyPI](https://img.shields.io/pypi/v/pylabrad.svg)](https://pypi.python.org/pypi/pylabrad)
 [![Build Status](https://secure.travis-ci.org/labrad/pylabrad.png)](http://travis-ci.org/labrad/pylabrad)
 [![Coverage Status](https://coveralls.io/repos/labrad/pylabrad/badge.svg)](https://coveralls.io/r/labrad/pylabrad)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Python Version](https://img.shields.io/badge/python-3.7+-blue.svg)
 [![PyPI](https://img.shields.io/pypi/v/pylabrad.svg)](https://pypi.python.org/pypi/pylabrad)
-[![Build Status](https://secure.travis-ci.org/labrad/pylabrad.png)](http://travis-ci.org/labrad/pylabrad)
+[![Build Status](https://secure.travis-ci.org/labrad/pylabrad.svg)](http://travis-ci.org/labrad/pylabrad)
 [![Coverage Status](https://coveralls.io/repos/labrad/pylabrad/badge.svg)](https://coveralls.io/r/labrad/pylabrad)
 
 pylabrad is an interface to the LabRAD system in python with support for both clients and servers.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # pylabrad
 
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pylabrad)
 [![PyPI](https://img.shields.io/pypi/v/pylabrad.svg)](https://pypi.python.org/pypi/pylabrad)
 [![Build Status](https://secure.travis-ci.org/labrad/pylabrad.png)](http://travis-ci.org/labrad/pylabrad)
 [![Coverage Status](https://coveralls.io/repos/labrad/pylabrad/badge.svg)](https://coveralls.io/r/labrad/pylabrad)


### PR DESCRIPTION
Closes #369.


c8ceaab vs efd9f1a: The one with a hardcoded version looks nicer IMO, but the version won't dynamically update with setup.py. Not sure which is preferred.