### PR TITLE
set futures to python 2 only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 configparser
 future
-futures >= 3.0.*
+futures >= 3.0.*; python_version < '3'
 numpy >= 1.12.*; python_version < '3.7'
 numpy >= 1.15.*; python_version == '3.7'
 numpy >= 1.17.*; python_version >= '3.8'


### PR DESCRIPTION
`futures` is not needed and supported by python 3. This requirement causes problem with `pip install pylabrad` command in a Windows 10, conda 4.10.1, and python 3.8.8 environment.